### PR TITLE
Update `Super Famicom.bml`

### DIFF
--- a/bsnes/Database/Super Famicom.bml
+++ b/bsnes/Database/Super Famicom.bml
@@ -1,5 +1,5 @@
 database
-  revision: 2020-01-01
+  revision: 2020-01-21
 
 //Prototypes (JPN)
 
@@ -125,7 +125,7 @@ game
 //Super Famicom (JPN)
 
 database
-  revision: 2020-01-01
+  revision: 2020-01-21
 
 game
   sha256:   5c4e283efc338958b8dd45ebd6daf133a9eb280420a98e2e1df358ae0242c366
@@ -169,6 +169,22 @@ game
     memory
       type: RAM
       size: 0x8000
+      content: Save
+
+game
+  sha256:   a98eb5f0521746e6ce6d208591e86d366b6e0479d96474bfff43856fe8cfec12
+  label:    バハムートラグーン
+  name:     Bahamut Lagoon
+  region:   SHVC-AXBJ-JPN
+  revision: SHVC-AXBJ-0
+  board:    SHVC-1J3M-20
+    memory
+      type: ROM
+      size: 0x300000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
       content: Save
 
 game
@@ -1459,6 +1475,22 @@ game
     memory
       type: ROM
       size: 0x2e0000
+      content: Program
+    memory
+      type: RAM
+      size: 0x2000
+      content: Save
+
+game
+  sha256:   77b2d5450ce3c87185f913c2584673530c13dfbe8cc433b1e9fe5e9a653bf7d5
+  label:    テイルズオブファンタジア
+  name:     Tales of Phantasia
+  region:   SHVC-ATVJ-JPN
+  revision: SHVC-ATVJ-0
+  board:    SHVC-LJ3M-01
+    memory
+      type: ROM
+      size: 0x600000
       content: Program
     memory
       type: RAM

--- a/bsnes/Database/Super Famicom.bml
+++ b/bsnes/Database/Super Famicom.bml
@@ -6053,7 +6053,7 @@ game
 //Super Nintendo (USA)
 
 database
-  revision: 2020-01-01
+  revision: 2020-07-27
 
 game
   sha256:   2ffe8828480f943056fb1ab5c3c84d48a0bf8cbe3ed7c9960b349b59adb07f3b
@@ -13361,6 +13361,24 @@ game
       size: 0x8000
       content: Save
       volatile
+
+game
+  sha256:   e134f20f6ee7d422d06faea6b1ae1e4101d1d0a200a0571d715d1cf23d959e8c
+  label:    Star Fox 2
+  name:     Star Fox 2
+  region:   USA
+  revision: 1.0
+  board:    GSU-RAM
+    memory
+      type: ROM
+      size: 0x100000
+      content: Program
+    memory
+      type: RAM
+      size: 0x10000
+      content: Save
+    oscillator
+      frequency: 21440000
 
 game
   sha256:   3a16ad45ae3d89b13c9e53e21c2a4c725ff7cec7fbe7896d538d163f92cb4aac


### PR DESCRIPTION
First commit updates `Super Famicom.bml` to the one of ares v115.

Second commit adds the official Star Fox 2 from Super NES Classic Edition. Since all Super NES Classic Edition games have USA localization, I chose `region: USA` and `revision: 1.0` like it's done with prototype boards. Since there is no physical board, I chose the generic `board: GSU-RAM` which is suggested by bsnes's heuristics. In the end this board definition is identical to the board `SHVC-1CA6B-01` used by Stunt Race FX which is considered a good donor cartridge. Does this make sense?