### PR TITLE
Consider the overscan setting when getting the aspect ratio

### DIFF
--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -46,20 +46,27 @@ static int aspect_ratio_mode = 0;
 
 static double get_aspect_ratio()
 {
+	double ratio;
+
 	if (aspect_ratio_mode == 0 && program->superFamicom.region == "NTSC")
-		return 1.306122;
+		ratio = 1.306122;
 	else if (aspect_ratio_mode == 0 && program->superFamicom.region == "PAL")
-		return 1.584216;
+		ratio = 1.584216;
 	else if (aspect_ratio_mode == 1) // 8:7
-		return 8.0/7.0;
+		ratio = 8.0/7.0;
 	else if (aspect_ratio_mode == 2) // 4:3
 		return 4.0/3.0;
 	else if (aspect_ratio_mode == 3) // NTSC
-		return 1.306122;
+		ratio = 1.306122;
 	else if (aspect_ratio_mode == 4) // PAL
-		return 1.584216;
+		ratio = 1.584216;
 	else
-		return 8.0/7.0; // Default
+		ratio = 8.0/7.0; // Default
+
+	if (program->overscan)
+		return (ratio / 240) * 224;
+	else
+		return ratio;
 }
 
 static void flush_variables()


### PR DESCRIPTION
I'm looking to move the libretro fork's parent over to this repo, since the original parent is now gone and I assume this is where the action will be taking place from here on out. This is the one commit we had locally that wasn't upstream, so I figured I'd offer it up: https://github.com/libretro/bsnes/commit/f04fe9bf5bfe8fc6a3ce3ee2c90747daf579258c