### PR TITLE
libretro: Add support for BS-X Satellaview

### DIFF
--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -41,8 +41,10 @@ static int aspect_ratio_mode = 0;
 #define RETRO_DEVICE_LIGHTGUN_JUSTIFIERS   RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_LIGHTGUN, 2)
 
 #define RETRO_GAME_TYPE_SGB             0x101 | 0x1000
+#define RETRO_GAME_TYPE_BSX             0x110 | 0x1000
 #define RETRO_MEMORY_SGB_SRAM ((1 << 8) | RETRO_MEMORY_SAVE_RAM)
 #define RETRO_MEMORY_GB_SRAM ((2 << 8) | RETRO_MEMORY_SAVE_RAM)
+#define RETRO_MEMORY_BSX_SRAM ((3 << 8) | RETRO_MEMORY_SAVE_RAM)
 
 static double get_aspect_ratio()
 {
@@ -333,23 +335,33 @@ static void set_controller_ports(unsigned port, unsigned device)
 static void set_environment_info(retro_environment_t cb)
 {
 
-    static const struct retro_subsystem_memory_info sgb_memory[] = {
-        { "srm", RETRO_MEMORY_SGB_SRAM },
-    };
+	static const struct retro_subsystem_memory_info sgb_memory[] = {
+		{ "srm", RETRO_MEMORY_SGB_SRAM },
+	};
 
-    static const struct retro_subsystem_memory_info gb_memory[] = {
-        { "srm", RETRO_MEMORY_GB_SRAM },
-    };
+	static const struct retro_subsystem_memory_info gb_memory[] = {
+		{ "srm", RETRO_MEMORY_GB_SRAM },
+	};
 
-    static const struct retro_subsystem_rom_info sgb_roms[] = {
-        { "Game Boy ROM", "gb|gbc", true, false, true, gb_memory, 1 },
-        { "Super Game Boy ROM", "smc|sfc|swc|fig|bs", true, false, true, sgb_memory, 1 },
-    };
+	static const struct retro_subsystem_memory_info bsx_memory[] = {
+		{ "srm", RETRO_MEMORY_BSX_SRAM },
+	};
 
-    static const struct retro_subsystem_info subsystems[] = {
-        { "Super Game Boy", "sgb", sgb_roms, 2, RETRO_GAME_TYPE_SGB },
-        {}
-    };
+	static const struct retro_subsystem_rom_info sgb_roms[] = {
+		{ "Game Boy ROM", "gb|gbc", true, false, true, gb_memory, 1 },
+		{ "Super Game Boy ROM", "smc|sfc|swc|fig", true, false, true, sgb_memory, 1 },
+	};
+
+	static const struct retro_subsystem_rom_info bsx_roms[] = {
+		{ "BS-X ROM", "bs", true, false, true, bsx_memory, 1 },
+		{ "BS-X BIOS ROM", "smc|sfc|swc|fig", true, false, true, bsx_memory, 1 },
+	};
+
+	static const struct retro_subsystem_info subsystems[] = {
+		{ "Super Game Boy", "sgb", sgb_roms, 2, RETRO_GAME_TYPE_SGB },
+		{ "BS-X Satellaview", "bsx", bsx_roms, 2, RETRO_GAME_TYPE_BSX },
+		{}
+	};
 
 	cb(RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO,  (void*)subsystems);
 
@@ -533,7 +545,7 @@ RETRO_API void retro_get_system_info(retro_system_info *info)
 	info->library_name     = "bsnes";
 	info->library_version  = Emulator::Version;
 	info->need_fullpath    = true;
-	info->valid_extensions = "smc|sfc|gb|gbc";
+	info->valid_extensions = "smc|sfc|gb|gbc|bs";
 	info->block_extract = false;
 }
 
@@ -690,6 +702,14 @@ RETRO_API bool retro_load_game_special(unsigned game_type,
 			libretro_print(RETRO_LOG_INFO, "GB ROM: %s\n", info[0].path);
 			libretro_print(RETRO_LOG_INFO, "SGB ROM: %s\n", info[1].path);
 			program->gameBoy.location = info[0].path;
+			program->superFamicom.location = info[1].path;
+		}
+		break;
+		case RETRO_GAME_TYPE_BSX:
+		{
+			libretro_print(RETRO_LOG_INFO, "BS-X ROM: %s\n", info[0].path);
+			libretro_print(RETRO_LOG_INFO, "BS-X BIOS ROM: %s\n", info[1].path);
+			program->bsMemory.location = info[0].path;
 			program->superFamicom.location = info[1].path;
 		}
 		break;


### PR DESCRIPTION
This adds support for the BS-X Satellaview to the libretro port. It works similarly to Super Game Boy.