### PR TITLE
Strip whitespace and empty lines from the cheat editor.

### DIFF
--- a/bsnes/target-bsnes/tools/cheat-editor.cpp
+++ b/bsnes/target-bsnes/tools/cheat-editor.cpp
@@ -101,11 +101,17 @@ auto CheatWindow::doChange() -> void {
 }
 
 auto CheatWindow::doAccept() -> void {
-  auto codes = codeValue.text().downcase().transform("+", "\n").split("\n").strip();
+  auto raw_codes = codeValue.text().downcase().transform("+", "\n").split("\n").strip();
+  vector<string> valid_codes;
   string invalid;  //if empty after below for-loop, code is considered valid
-  for(auto& code : codes) {
+  for(auto& code : raw_codes) {
+    if(code.length() == 0) {
+      continue;
+    }
     if(!program.gameBoy.program) {
-      if(!cheatEditor.decodeSNES(code)) {
+      if(cheatEditor.decodeSNES(code)) {
+        valid_codes.append(code);
+      } else {
         invalid =
           "Invalid code(s), please only use codes in the following format:\n"
           "\n"
@@ -115,7 +121,9 @@ auto CheatWindow::doAccept() -> void {
           "higan (aaaaaa=cc?dd)";
       }
     } else {
-      if(!cheatEditor.decodeGB(code)) {
+      if(cheatEditor.decodeGB(code)) {
+        valid_codes.append(code);
+      } else {
         invalid =
           "Invalid code(s), please only use codes in the following format:\n"
           "\n"
@@ -129,7 +137,7 @@ auto CheatWindow::doAccept() -> void {
   }
   if(invalid) return (void)MessageDialog().setAlignment(*toolsWindow).setText(invalid).error();
 
-  Cheat cheat = {nameValue.text().strip(), codes.merge("+"), enableOption.checked()};
+  Cheat cheat = {nameValue.text().strip(), valid_codes.merge("+"), enableOption.checked()};
   if(acceptButton.text() == "Add") {
     cheatEditor.addCheat(cheat);
   } else {


### PR DESCRIPTION
Previously, bsnes would turn the cheat text into a list of cheats by splitting on '\n', producing an empty "cheat" after the last line of the editor:

    "7e0003=00\n".split("\n") -> ["7e0003=00", ""]

That empty "cheat" is not a valid cheat, so the result would be marked invalid. Teaching bsnes to silently skip empty lines worked, but it would preserve multiple blank lines between two cheats, which was silly.

Now we iterate over all the lines of the cheat editor, putting valid codes in a new vector, and setting a flag for invalid codes.

This fix works for me, but I would particularly appreciate code-review from people who understand C++ memory-management - in Rust you can't move items from one vector to another unless iterating over the old vector consumes it and will release its memory; it's not clear to me whether nall's vector iteration is consuming or read-only, or whether the item is copied or moved to the new vector. It *probably* doesn't matter, since both vectors are local variables and the only storage to escape the function is a freshly-allocated string regardless, but I'd like to know for future reference.

Fixes #63.