### PR TITLE
nall: Use unprefixed endian defines from endian.h.

### DIFF
--- a/nall/intrinsics.hpp
+++ b/nall/intrinsics.hpp
@@ -121,6 +121,15 @@ namespace nall {
   #include <machine/endian.h>
 #elif defined(PLATFORM_LINUX)
   #include <endian.h>
+  #ifndef BYTE_ORDER
+    #define BYTE_ORDER __BYTE_ORDER
+  #endif
+  #ifndef LITTLE_ENDIAN
+    #define LITTLE_ENDIAN __LITTLE_ENDIAN
+  #endif
+  #ifndef BIG_ENDIAN
+    #define BIG_ENDIAN __BIG_ENDIAN
+  #endif
 #elif defined(PLATFORM_BSD)
   #include <sys/endian.h>
 #endif
@@ -159,10 +168,10 @@ namespace nall {
 
 namespace nall {
 
-#if (defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && __BYTE_ORDER == __LITTLE_ENDIAN) || defined(__LITTLE_ENDIAN__) || defined(__i386__) || defined(__amd64__) || defined(_M_IX86) || defined(_M_AMD64)
+#if (defined(BYTE_ORDER) && defined(LITTLE_ENDIAN) && BYTE_ORDER == LITTLE_ENDIAN) || defined(__LITTLE_ENDIAN__) || defined(__i386__) || defined(__amd64__) || defined(_M_IX86) || defined(_M_AMD64)
   #define ENDIAN_LSB
   constexpr auto endian() -> Endian { return Endian::LSB; }
-#elif (defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && __BYTE_ORDER == __BIG_ENDIAN) || defined(__BIG_ENDIAN__) || defined(__powerpc__) || defined(_M_PPC)
+#elif (defined(BYTE_ORDER) && defined(BIG_ENDIAN) && BYTE_ORDER == BIG_ENDIAN) || defined(__BIG_ENDIAN__) || defined(__powerpc__) || defined(_M_PPC)
   #define ENDIAN_MSB
   constexpr auto endian() -> Endian { return Endian::MSB; }
 #else


### PR DESCRIPTION
From what I can tell every system with `<endian.h>` has `BYTE_ORDER`, `BIG_ENDIAN`, and `LITTLE_ENDIAN` without a double-underscore __prefix.

* [macOS (best I could find)](https://opensource.apple.com/source/xnu/xnu-4570.71.2/bsd/arm/endian.h.auto.html)
* [FreeBSD](http://bxr.su/FreeBSD/sys/arm/include/endian.h#54)
* [NetBSD](http://bxr.su/NetBSD/sys/sys/endian.h#94)
* [OpenBSD](http://bxr.su/OpenBSD/sys/sys/endian.h#43)
* [POSIX](https://www.austingroupbugs.net/view.php?id=162#c665)
* [glibc libc](https://code.woboq.org/userspace/glibc/string/endian.h.html#44)
* [musl libc](https://github.com/cloudius-systems/musl/blob/master/include/endian.h#L16)

On Linux, define these macros to the double underscore variants if they're missing, just in case they're not defined properly on older versions.

On Windows, I think it's covered by the `defined(_M_IX86) || defined(_M_AMD64)` part.
 
This fixes endian detection and lets bsnes build on NetBSD/aarch64, which does not have the prefixed defines.