### PR TITLE
Fix auto-joypad polling

### DIFF
--- a/bsnes/sfc/cpu/cpu.hpp
+++ b/bsnes/sfc/cpu/cpu.hpp
@@ -120,7 +120,7 @@ private:
 
     bool autoJoypadActive = 0;
     bool autoJoypadLatch = 0;
-    uint autoJoypadCounter = 0;
+    uint autoJoypadCounter = 33;  //state machine; 4224 / 128 = 33 (inactive)
   } status;
 
   struct IO {

--- a/bsnes/sfc/cpu/io.cpp
+++ b/bsnes/sfc/cpu/io.cpp
@@ -12,11 +12,13 @@ auto CPU::readCPU(uint addr, uint8 data) -> uint8 {
   case 0x2180:  //WMDATA
     return bus.read(0x7e0000 | io.wramAddress++, data);
 
+  //todo: it is not known what happens when reading from this register during auto-joypad polling
   case 0x4016:  //JOYSER0
     data &= 0xfc;
     data |= controllerPort1.device->data();
     return data;
 
+  //todo: it is not known what happens when reading from this register during auto-joypad polling
   case 0x4017:  //JOYSER1
     data &= 0xe0;
     data |= 0x1c;  //pins are connected to GND
@@ -48,6 +50,7 @@ auto CPU::readCPU(uint addr, uint8 data) -> uint8 {
   case 0x4216: return io.rdmpy >> 0;  //RDMPYL
   case 0x4217: return io.rdmpy >> 8;  //RDMPYH
 
+  //todo: it is not known what happens when reading from these registers during auto-joypad polling
   case 0x4218: return io.joy1 >> 0;   //JOY1L
   case 0x4219: return io.joy1 >> 8;   //JOY1H
   case 0x421a: return io.joy2 >> 0;   //JOY2L
@@ -122,6 +125,7 @@ auto CPU::writeCPU(uint addr, uint8 data) -> void {
     io.wramAddress = io.wramAddress & 0x0ffff | (data & 1) << 16;
     return;
 
+  //todo: it is not known what happens when writing to this register during auto-joypad polling
   case 0x4016:  //JOYSER0
     //bit 0 is shared between JOYSER0 and JOYSER1:
     //strobing $4016.d0 affects both controller port latches.
@@ -130,6 +134,7 @@ auto CPU::writeCPU(uint addr, uint8 data) -> void {
     controllerPort2.device->latch(data & 1);
     return;
 
+  //todo: it is not known what happens when writing to this register during auto-joypad polling
   case 0x4200:  //NMITIMEN
     io.autoJoypadPoll = data & 1;
     nmitimenUpdate(data);

--- a/bsnes/sfc/cpu/timing.cpp
+++ b/bsnes/sfc/cpu/timing.cpp
@@ -200,7 +200,7 @@ auto CPU::dmaEdge() -> void {
   }
 }
 
-//called every 128 clocks; see CPU::step()
+//called every 128 clocks from inside the CPU::stepOnce() function
 auto CPU::joypadEdge() -> void {
   //it is not yet confirmed if polling can be stopped early and/or (re)started later
   if(!io.autoJoypadPoll) return;

--- a/bsnes/sfc/interface/configuration.cpp
+++ b/bsnes/sfc/interface/configuration.cpp
@@ -21,7 +21,6 @@ auto Configuration::process(Markup::Node document, bool load) -> void {
   bind(text,    "Hacks/Entropy", hacks.entropy);
   bind(natural, "Hacks/CPU/Overclock", hacks.cpu.overclock);
   bind(boolean, "Hacks/CPU/FastMath", hacks.cpu.fastMath);
-  bind(boolean, "Hacks/CPU/FastJoypadPolling", hacks.cpu.fastJoypadPolling);
   bind(boolean, "Hacks/PPU/Fast", hacks.ppu.fast);
   bind(boolean, "Hacks/PPU/Deinterlace", hacks.ppu.deinterlace);
   bind(natural, "Hacks/PPU/RenderCycle", hacks.ppu.renderCycle);

--- a/bsnes/sfc/interface/configuration.hpp
+++ b/bsnes/sfc/interface/configuration.hpp
@@ -33,7 +33,6 @@ struct Configuration {
     struct CPU {
       uint overclock = 100;
       bool fastMath = false;
-      bool fastJoypadPolling = false;
     } cpu;
     struct PPU {
       bool fast = true;

--- a/bsnes/target-bsnes/program/hacks.cpp
+++ b/bsnes/target-bsnes/program/hacks.cpp
@@ -1,6 +1,5 @@
 auto Program::hackCompatibility() -> void {
   string entropy = settings.emulator.hack.entropy;
-  bool fastJoypadPolling = false;
   bool fastPPU = settings.emulator.hack.ppu.fast;
   bool fastPPUNoSpriteLimit = settings.emulator.hack.ppu.noSpriteLimit;
   bool fastDSP = settings.emulator.hack.dsp.fast;
@@ -9,15 +8,6 @@ auto Program::hackCompatibility() -> void {
 
   auto title = superFamicom.title;
   auto region = superFamicom.region;
-
-  //sometimes menu options are skipped over in the main menu with cycle-based joypad polling
-  if(title == "Arcades Greatest Hits") fastJoypadPolling = true;
-
-  //the start button doesn't work in this game with cycle-based joypad polling
-  if(title == "TAIKYOKU-IGO Goliath") fastJoypadPolling = true;
-
-  //holding up or down on the menu quickly cycles through options instead of stopping after each button press
-  if(title == "WORLD MASTERS GOLF") fastJoypadPolling = true;
 
   //relies on mid-scanline rendering techniques
   if(title == "AIR STRIKE PATROL" || title == "DESERT FIGHTER") fastPPU = false;
@@ -67,7 +57,6 @@ auto Program::hackCompatibility() -> void {
   }
 
   emulator->configure("Hacks/Entropy", entropy);
-  emulator->configure("Hacks/CPU/FastJoypadPolling", fastJoypadPolling);
   emulator->configure("Hacks/PPU/Fast", fastPPU);
   emulator->configure("Hacks/PPU/NoSpriteLimit", fastPPUNoSpriteLimit);
   emulator->configure("Hacks/PPU/RenderCycle", renderCycle);

--- a/bsnes/target-libretro/program.cpp
+++ b/bsnes/target-libretro/program.cpp
@@ -165,15 +165,6 @@ auto Program::load() -> void {
 	auto title = superFamicom.title;
 	auto region = superFamicom.region;
 
-	//sometimes menu options are skipped over in the main menu with cycle-based joypad polling
-	if(title == "Arcades Greatest Hits") emulator->configure("Hacks/CPU/FastJoypadPolling", true);
-
-	//the start button doesn't work in this game with cycle-based joypad polling
-	if(title == "TAIKYOKU-IGO Goliath") emulator->configure("Hacks/CPU/FastJoypadPolling", true);
-
-	//holding up or down on the menu quickly cycles through options instead of stopping after each button press
-	if(title == "WORLD MASTERS GOLF") emulator->configure("Hacks/CPU/FastJoypadPolling", true);
-
 	//relies on mid-scanline rendering techniques
 	if(title == "AIR STRIKE PATROL" || title == "DESERT FIGHTER") emulator->configure("Hacks/PPU/Fast", false);
 


### PR DESCRIPTION
This merges SNES auto-joypad polling fixes. The new code runs the auto-joypad polling at 128-cycle granularity instead of 256-cycle granularity, so that the first event can happen ~128 cycles after the start of Vblank. I've left comments for the unknown behaviors. I also removed the hacks since they are no longer needed.

This fixes issue 3 of 3 for https://github.com/bsnes-emu/bsnes/issues/61, which means we can close issue 61 now.

I have tested and confirmed these fixes work with every game affected.