### PR TITLE
Use byuu.org/bsnes as the official homepage.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -3,7 +3,7 @@ bsnes - Super Nintendo emulator
 
   Copyright © 2004-2020 byuu et al
 
-  https://github.com/bsnes-emu
+  https://byuu.org/bsnes/
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/bsnes/emulator/emulator.hpp
+++ b/bsnes/emulator/emulator.hpp
@@ -32,7 +32,7 @@ namespace Emulator {
   static const string Version   = "115";
   static const string Copyright = "byuu et al";
   static const string License   = "GPLv3 or later";
-  static const string Website   = "https://github.com/bsnes-emu";
+  static const string Website   = "https://byuu.org/bsnes/";
 
   //incremented only when serialization format changes
   static const string SerializerVersion = "115";


### PR DESCRIPTION
Previously, we didn't have control of byuu.org and it wasn't obvious what we should do about hosting. Now we can update byuu.org, though, we should continue using it as the authoritative source information.

Fixes #2.