### PR TITLE
nall: Support all the names endian.h provides on common platforms.

### DIFF
--- a/nall/intrinsics.hpp
+++ b/nall/intrinsics.hpp
@@ -117,14 +117,6 @@ namespace nall {
 
 }
 
-#if defined(PLATFORM_MACOS)
-  #include <machine/endian.h>
-#elif defined(PLATFORM_LINUX)
-  #include <endian.h>
-#elif defined(PLATFORM_BSD)
-  #include <sys/endian.h>
-#endif
-
 /* Architecture detection */
 
 namespace nall {
@@ -157,12 +149,44 @@ namespace nall {
 
 /* Endian detection */
 
+#if defined(PLATFORM_MACOS)
+  #include <machine/endian.h>
+#elif defined(PLATFORM_LINUX)
+  #include <endian.h>
+#elif defined(PLATFORM_BSD)
+  #include <sys/endian.h>
+#endif
+
 namespace nall {
 
-#if (defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && __BYTE_ORDER == __LITTLE_ENDIAN) || defined(__LITTLE_ENDIAN__) || defined(__i386__) || defined(__amd64__) || defined(_M_IX86) || defined(_M_AMD64)
+// A note on endian constants: Traditional UNIX provides a header that defines
+// constants LITTLE_ENDIAN, BIG_ENDIAN, and BYTE_ORDER (set to LITTLE_ENDIAN or
+// BIG_ENDIAN as appropriate). However, C89 says that the compiler/libc should
+// not introduce any names unless they start with an underscore, so when you're
+// compiling in standards-compilant mode, those constants are named
+// __LITTLE_ENDIAN, or sometimes _LITTLE_ENDIAN, or sometimes even LITTLE_ENDIAN
+// on platforms that care more about tradition than standards. The platforms
+// that rename the constants usually provide some other name you can #define to
+// say, "forget C89, yes I really want traditional constant names", but *that*
+// name also differs from platform to platform, and it affects more than just
+// the endian header.
+//
+// Rather than wade into that mess, let's just test for all the constants we
+// know about.
+
+#if  (defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && __BYTE_ORDER == __LITTLE_ENDIAN) \
+  || (defined( _BYTE_ORDER) && defined( _LITTLE_ENDIAN) &&  _BYTE_ORDER ==  _LITTLE_ENDIAN) \
+  || (defined(  BYTE_ORDER) && defined(  LITTLE_ENDIAN) &&   BYTE_ORDER ==   LITTLE_ENDIAN) \
+  || defined(__LITTLE_ENDIAN__) \
+  || defined(__i386__) || defined(__amd64__) \
+  || defined(_M_IX86) || defined(_M_AMD64)
   #define ENDIAN_LSB
   constexpr auto endian() -> Endian { return Endian::LSB; }
-#elif (defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && __BYTE_ORDER == __BIG_ENDIAN) || defined(__BIG_ENDIAN__) || defined(__powerpc__) || defined(_M_PPC)
+#elif(defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && __BYTE_ORDER == __BIG_ENDIAN) \
+  || (defined( _BYTE_ORDER) && defined( _BIG_ENDIAN) &&  _BYTE_ORDER ==  _BIG_ENDIAN) \
+  || (defined(  BYTE_ORDER) && defined(  BIG_ENDIAN) &&   BYTE_ORDER ==   BIG_ENDIAN) \
+  || defined(__BIG_ENDIAN__) \
+  || defined(__powerpc__) || defined(_M_PPC)
   #define ENDIAN_MSB
   constexpr auto endian() -> Endian { return Endian::MSB; }
 #else


### PR DESCRIPTION
Also, moved the snippet that includes endian.h beneath the "Endian detection" header, since I think it fits more neatly there.

Fixes #77.