### PR TITLE
target-bsnes: Fix crash when clicking in an empty row while assiging inputs

### DIFF
--- a/bsnes/target-bsnes/settings/input.cpp
+++ b/bsnes/target-bsnes/settings/input.cpp
@@ -67,7 +67,7 @@ auto InputSettings::updateControls() -> void {
   assignMouse2.setVisible(false);
   assignMouse3.setVisible(false);
 
-  if(activeMapping) {
+  if(activeMapping && batched) {
     auto& input = activeDevice().mappings[batched.left().offset()];
     if(input.isDigital()) {
       assignMouse1.setVisible().setText("Mouse Left");


### PR DESCRIPTION
When assigning an input, you can click on a different row of the bindings table to change which input you're assigning. As well as listening for keyboard and controller input, bsnes displays buttons to map the mouse axes or mouse buttons, depending on whether the new row you've selected represents an analog or digital input.

However, some controllers do not have enough inputs to fill the default size of the input table. If you click below the last row, then *no* input is selected, and when bsnes tries to find the input associated with that not-a-row, it crashes.

The solution is, only show the mouse axis/mouse button buttons when a valid row is selected.

Mentioned in #75.