### PR TITLE
target-bsnes: Fixes for a couple of input settings bugs.

### DIFF
--- a/bsnes/target-bsnes/settings/input.cpp
+++ b/bsnes/target-bsnes/settings/input.cpp
@@ -68,12 +68,11 @@ auto InputSettings::updateControls() -> void {
   assignMouse3.setVisible(false);
 
   if(activeMapping) {
-    auto& input = activeDevice().mappings[batched.left().offset()];
-    if(input.isDigital()) {
+    if(activeMapping->isDigital()) {
       assignMouse1.setVisible().setText("Mouse Left");
       assignMouse2.setVisible().setText("Mouse Middle");
       assignMouse3.setVisible().setText("Mouse Right");
-    } else if(input.isAnalog()) {
+    } else if(activeMapping->isAnalog()) {
       assignMouse1.setVisible().setText("Mouse X-axis");
       assignMouse2.setVisible().setText("Mouse Y-axis");
     }
@@ -146,6 +145,7 @@ auto InputSettings::assignMapping(TableViewCell cell) -> void {
   inputManager.poll();  //clear any pending events first
 
   for(auto mapping : mappingList.batched()) {
+    refreshMappings();  //clear existing 'assign...' text
     activeMapping = activeDevice().mappings[mapping.offset()];
     activeBinding = max(0, (int)cell.offset() - 1);
     mappingList.item(mapping.offset()).cell(1 + activeBinding).setIcon(Icon::Go::Right).setText("(assign ...)");


### PR DESCRIPTION
-   Fixes a bug where the program may crash or display improper buttons when changing the selected row during assignment.

    This appears to just be a mistake, accidentally using the 'batched' rows instead of the activeMapping row.

-   Fixes a bug where starting multiple assignments without finishing one leads to stale "Assigning..." text in some rows.

    This appears to be an oversight. Simply refreshing the mappings before starting an assignment fixes this.

This patch should supersede #95 if testing proves that it works as intended across all platforms as it is more straightforwardly-correct (this fixes not only a crash, but also a logical error that can lead to at least one impossible assignment.)

| Before | After |
| --- | --- |
| ![Animation displaying several input bugs as described above.](https://user-images.githubusercontent.com/938744/98450978-6dbbcd00-20f6-11eb-875b-5a31019bfb58.gif) | ![Animation showing the inability to reproduce the bugs described above.](https://user-images.githubusercontent.com/938744/98451033-f2a6e680-20f6-11eb-9c89-437d0efb182f.gif) |