### PR TITLE
target-bsnes: Rework screensaver suppression

### DIFF
--- a/bsnes/target-bsnes/bsnes.cpp
+++ b/bsnes/target-bsnes/bsnes.cpp
@@ -40,7 +40,6 @@ auto nall::main(Arguments arguments) -> void {
 
   settings.load();
   Application::setName("bsnes");
-  Application::setScreenSaver(settings.general.screenSaver);
   Application::setToolTips(settings.general.toolTips);
 
   Instances::presentation.construct();

--- a/bsnes/target-bsnes/program/program.cpp
+++ b/bsnes/target-bsnes/program/program.cpp
@@ -85,7 +85,16 @@ auto Program::main() -> void {
   inputManager.poll();
   inputManager.pollHotkeys();
 
-  if(inactive()) {
+  static bool previouslyInactive = true;
+  bool currentlyInactive = inactive();
+
+  // check if emulator has transitioned from active to inactive or vice versa
+  if(previouslyInactive != currentlyInactive) {
+    previouslyInactive = currentlyInactive;
+    Application::setScreenSaver(currentlyInactive || settings.general.screenSaver);
+  }
+
+  if(currentlyInactive) {
     audio.clear();
     usleep(20 * 1000);
     if(settings.emulator.runAhead.frames == 0) viewportRefresh();

--- a/bsnes/target-bsnes/settings/emulator.cpp
+++ b/bsnes/target-bsnes/settings/emulator.cpp
@@ -23,6 +23,9 @@ auto EmulatorSettings::create() -> void {
   nativeFileDialogs.setText("Use native file dialogs").setChecked(settings.general.nativeFileDialogs).onToggle([&] {
     settings.general.nativeFileDialogs = nativeFileDialogs.checked();
   });
+  screenSaver.setText("Allow screensaver during emulation").setChecked(settings.general.screenSaver).onToggle([&] {
+    settings.general.screenSaver = screenSaver.checked();
+  });
   optionsSpacer.setColor({192, 192, 192});
 
   fastForwardLabel.setText("Fast Forward").setFont(Font().setBold());

--- a/bsnes/target-bsnes/settings/emulator.cpp
+++ b/bsnes/target-bsnes/settings/emulator.cpp
@@ -25,6 +25,8 @@ auto EmulatorSettings::create() -> void {
   });
   screenSaver.setText("Allow screensaver during emulation").setChecked(settings.general.screenSaver).onToggle([&] {
     settings.general.screenSaver = screenSaver.checked();
+    // setting can be toggled while emulation is active
+    if(!program.inactive()) Application::setScreenSaver(settings.general.screenSaver);
   });
   optionsSpacer.setColor({192, 192, 192});
 

--- a/bsnes/target-bsnes/settings/settings.hpp
+++ b/bsnes/target-bsnes/settings/settings.hpp
@@ -309,6 +309,7 @@ public:
     CheckLabel autoSaveStateOnUnload{&autoStateLayout, Size{0, 0}};
     CheckLabel autoLoadStateOnLoad{&autoStateLayout, Size{0, 0}};
   CheckLabel nativeFileDialogs{this, Size{~0, 0}};
+  CheckLabel screenSaver{this, Size{~0, 0}};
   Canvas optionsSpacer{this, Size{~0, 1}};
   //
   Label fastForwardLabel{this, Size{~0, 0}, 2};


### PR DESCRIPTION
Fixes #87.

This PR implements the missing hiro/cocoa functionality to make this feature work on macOS and makes the setting configurable in the UI. Additionally, because I felt it doesn't make sense to suppress screensavers when nothing is loaded, I made some changes so the feature only kicks in when emulation is active.