### PR TITLE
sfc: Report auto joypad polling in the HVBJOY register.

### DIFF
--- a/bsnes/sfc/cpu/io.cpp
+++ b/bsnes/sfc/cpu/io.cpp
@@ -38,7 +38,7 @@ auto CPU::readCPU(uint addr, uint8 data) -> uint8 {
 
   case 0x4212:  //HVBJOY
     data &= 0x3e;
-    data |= (status.autoJoypadActive) << 0;
+    data |= io.autoJoypadPoll && status.autoJoypadCounter < 33;
     data |= (hcounter() <= 2 || hcounter() >= 1096) << 6;  //hblank
     data |= (vcounter() >= ppu.vdisp()) << 7;              //vblank
     return data;


### PR DESCRIPTION
This corrects the reporting bit of HVBJOY to be set during the auto joypad polling sequence.

This change will fix *SpellCraft - Aspects of Valor*. SpellCraft works by polling JOY1 nonstop once menus are entered on every scanline, so with incorrect HVBJOY bit 0 reporting, the game was thinking it was safe to read JOY1 during the auto joypad polling sequence, so partially shifted in results were being read back as valid. With this patch, you'll find that the game stops polling between V:225 H:130 and V:228 H:256, which is the auto polling time range. Before, it was polling during that time. As a result of this fix, the password menu can be accessed safely without it closing immediately.

Fixes #86.