### PR TITLE
hiro: Fix screensaver suspension under GNOME on X11.

### DIFF
--- a/hiro/gtk/application.cpp
+++ b/hiro/gtk/application.cpp
@@ -97,9 +97,7 @@ auto pApplication::initialize() -> void {
       InputOutput, DefaultVisual(state().display, screen),
       CWBackPixel | CWBorderPixel | CWOverrideRedirect, &attributes
     );
-  //note: hopefully xdg-screensaver does not require the window to be mapped ...
-  //if it does, we're in trouble: a small 1x1 black pixel window will be visible in said case
-    XMapWindow(state().display, state().screenSaverWindow);
+    XStoreName(state().display, state().screenSaverWindow, "hiro screensaver-prevention window");
     XFlush(state().display);
   }
   #endif

--- a/hiro/qt/application.cpp
+++ b/hiro/qt/application.cpp
@@ -94,9 +94,7 @@ auto pApplication::initialize() -> void {
       InputOutput, DefaultVisual(state().display, screen),
       CWBackPixel | CWBorderPixel | CWOverrideRedirect, &attributes
     );
-  //note: hopefully xdg-screensaver does not require the window to be mapped ...
-  //if it does, we're in trouble: a small 1x1 black pixel window will be visible in said case
-    XMapWindow(state().display, state().screenSaverWindow);
+    XStoreName(state().display, state().screenSaverWindow, "hiro screensaver-prevention window");
     XFlush(state().display);
   }
   #endif


### PR DESCRIPTION
On X11, hiro uses the xdg-screensaver helper tool to disable the screensaver, which detects the screensaver that is running and uses the appropriate mechanism to communicate with it. The tool's API expects an X11 window ID,
but at least some screensavers ignore it, so it can be set up however. The GNOME backend *does* care about the window ID, but its expectations are not documented anywhere, so byuu spent a frustrating few days trying things at random to get it working, and failing.

It turns out, GNOME does *not* require the window to be mapped, but it *does* require the window to have a name. Using XStoreName() to name the window fixes screensaver suspension for me under GNOME 3.38.

Note: while XStoreName is technically deprecated, it's not going to go away while X11 is still around, and the reason it's deprecated is because it doesn't include character encoding data. We don't care — no user should ever see the
window name, and it's plain ASCII so it should be fine.

Fixes #102.