### PR TITLE
Add shared data to search paths

### DIFF
--- a/bsnes/target-bsnes/bsnes.cpp
+++ b/bsnes/target-bsnes/bsnes.cpp
@@ -12,6 +12,9 @@ auto locate(string name) -> string {
   location = {Path::userData(), "bsnes/", name};
   if(inode::exists(location)) return location;
 
+  location = {Path::sharedData(), "bsnes/", name};
+  if(inode::exists(location)) return location;
+
   directory::create({Path::userSettings(), "bsnes/"});
   return {Path::userSettings(), "bsnes/", name};
 }


### PR DESCRIPTION
This is the patch I am currently using for the Flatpak to enable lookup for files installed under `/usr/share/bsnes` (read-only, common to all users). User data remains the first directory searched through, with shared data used as a fallback. Considering how file location is implemented in `bsnes`, I believe that's the least invasive approach to support shared data without breaking existing installs.