### PR TITLE
Fix hiro GTK3 menubar color when using custom window background color (fixes #108)

### DIFF
--- a/hiro/gtk/window.hpp
+++ b/hiro/gtk/window.hpp
@@ -36,6 +36,7 @@ struct pWindow : pObject {
   auto _menuHeight() const -> int;
   auto _menuTextHeight() const -> int;
   auto _setIcon(const string& basename) -> bool;
+  auto _setMenuColor() -> void;
   auto _setMenuEnabled(bool enabled) -> void;
   auto _setMenuFont(const Font& font) -> void;
   auto _setMenuVisible(bool visible) -> void;


### PR DESCRIPTION
When bsnes (or other hiro application) set a custom background color,
the GTK3 menubar color takes on the custom window background color.
So for instance in bsnes, this makes the menubar back, with black text,
making the menubar unreadable.

What this patch does is use the default menubar colors when no custom window
background color is used. When one is set (or removed) via
Window::setBackgroundColor, the new pWindow::_setMenuColor function is called.

This function sets the default menubar colors if the custom window color
option has been disabled, and sets it to the GTK3 theme background color,
which is the same as the menubar color, if a custom window color has been set.
We don't have to modify the text because there is no hiro option to set the
parent window text color.

If retrieving the theme background color value fails, and we have a custom
window color, this patch has one last fallback where it will set a light gray
menu color with black text.

On GTK2, this patch has no effect as it is not needed. GTK2 doesn't use
transparent menubars.