### PR TITLE
target-bsnes: Do not set the window background colour.

### DIFF
--- a/bsnes/target-bsnes/presentation/presentation.cpp
+++ b/bsnes/target-bsnes/presentation/presentation.cpp
@@ -213,8 +213,8 @@ auto Presentation::create() -> void {
 
   iconLayout.setAlignment(0.0).setCollapsible();
   image icon{Resource::Icon};
-  icon.alphaBlend(0x000000);
-  iconCanvas.setIcon(icon);
+  iconCanvas.setIcon(icon, {0, 0, 0});
+  iconCanvas.setAlignment({0.0, 0.0});
   iconCanvas.setDroppable();
   iconCanvas.onDrop([&](auto locations) { onDrop(locations); });
 
@@ -250,7 +250,6 @@ auto Presentation::create() -> void {
   });
 
   setTitle({"bsnes v", Emulator::Version});
-  setBackgroundColor({0, 0, 0});
   resizeWindow();
   setAlignment(Alignment::Center);
 

--- a/bsnes/target-bsnes/presentation/presentation.hpp
+++ b/bsnes/target-bsnes/presentation/presentation.hpp
@@ -126,7 +126,7 @@ struct Presentation : Window {
       Viewport viewport{&viewportLayout, Size{~0, ~0}, 0};
       VerticalLayout iconLayout{&viewportLayout, Size{0, ~0}, 0};
         Canvas iconSpacer{&iconLayout, Size{144, ~0}, 0};
-        Canvas iconCanvas{&iconLayout, Size{128, 128}, 0};
+        Canvas iconCanvas{&iconLayout, Size{144, 128}, 0};
     HorizontalLayout statusLayout{&layout, Size{~0, StatusHeight}, 0};
       Label spacerIcon{&statusLayout, Size{8, ~0}, 0};
       Canvas statusIcon{&statusLayout, Size{16, ~0}, 0};

--- a/hiro/core/shared.hpp
+++ b/hiro/core/shared.hpp
@@ -236,7 +236,7 @@ struct Canvas : sCanvas {
   auto setAlignment(Alignment alignment = {}) { return self().setAlignment(alignment), *this; }
   auto setColor(Color color) { return self().setColor(color), *this; }
   auto setGradient(Gradient gradient = {}) { return self().setGradient(gradient), *this; }
-  auto setIcon(const image& icon = {}) { return self().setIcon(icon), *this; }
+  auto setIcon(const image& icon = {}, Color padding = {}) { return self().setIcon(icon, padding), *this; }
   auto setSize(Size size = {}) { return self().setSize(size), *this; }
   auto update() { return self().update(), *this; }
 };

--- a/hiro/core/widget/canvas.cpp
+++ b/hiro/core/widget/canvas.cpp
@@ -48,11 +48,11 @@ auto mCanvas::setGradient(Gradient gradient) -> type& {
   return *this;
 }
 
-auto mCanvas::setIcon(const image& icon) -> type& {
-  state.color = {};
+auto mCanvas::setIcon(const image& icon, Color padding) -> type& {
+  state.color = padding;
   state.gradient = {};
   state.icon = icon;
-  signal(setIcon, icon);
+  signal(setIcon, icon, padding);
   return *this;
 }
 

--- a/hiro/core/widget/canvas.hpp
+++ b/hiro/core/widget/canvas.hpp
@@ -10,7 +10,7 @@ struct mCanvas : mWidget {
   auto setAlignment(Alignment alignment = {}) -> type&;
   auto setColor(Color color = {}) -> type&;
   auto setGradient(Gradient gradient = {}) -> type&;
-  auto setIcon(const image& icon = {}) -> type&;
+  auto setIcon(const image& icon = {}, Color padding = {0,0,0,0}) -> type&;
   auto setSize(Size size = {}) -> type&;
   auto size() const -> Size;
   auto update() -> type&;

--- a/hiro/gtk/widget/canvas.cpp
+++ b/hiro/gtk/widget/canvas.cpp
@@ -103,7 +103,7 @@ auto pCanvas::setGradient(Gradient gradient) -> void {
   update();
 }
 
-auto pCanvas::setIcon(const image& icon) -> void {
+auto pCanvas::setIcon(const image& icon, Color padding) -> void {
   update();
 }
 
@@ -136,7 +136,7 @@ auto pCanvas::_onDraw(cairo_t* context) -> void {
     dy = 0;
   }
 
-  cairo_set_source_rgba(context, 0.0, 0.0, 0.0, 0.0);
+  cairo_set_source_rgba(context, state().color.red() / 255.0, state().color.green() / 255.0, state().color.blue() / 255.0, state().color.alpha() / 255.0);
   cairo_paint(context);
   gdk_cairo_set_source_pixbuf(context, surface, dx - sx, dy - sy);
   cairo_rectangle(context, dx, dy, width, height);

--- a/hiro/gtk/widget/canvas.hpp
+++ b/hiro/gtk/widget/canvas.hpp
@@ -12,7 +12,7 @@ struct pCanvas : pWidget {
   auto setFocusable(bool focusable) -> void override;
   auto setGeometry(Geometry geometry) -> void override;
   auto setGradient(Gradient gradient) -> void;
-  auto setIcon(const image& icon) -> void;
+  auto setIcon(const image& icon, Color padding) -> void;
   auto update() -> void;
 
   auto _onDraw(cairo_t* context) -> void;

--- a/hiro/qt/widget/canvas.cpp
+++ b/hiro/qt/widget/canvas.cpp
@@ -47,7 +47,7 @@ auto pCanvas::setGradient(Gradient gradient) -> void {
   update();
 }
 
-auto pCanvas::setIcon(const image& icon) -> void {
+auto pCanvas::setIcon(const image& icon, Color padding) -> void {
   update();
 }
 
@@ -160,7 +160,10 @@ auto QtCanvas::paintEvent(QPaintEvent* event) -> void {
     height = geometry.height();
   }
 
+  Color padding = p.state().color;
+
   QPainter painter(p.qtCanvas);
+  painter.fillRect(0, 0, geometry.width(), geometry.height(), QColor(padding.red(), padding.green(), padding.blue(), padding.alpha()));
   painter.drawImage(dx, dy, *p.qtImage, sx, sy, width, height);
 }
 

--- a/hiro/qt/widget/canvas.hpp
+++ b/hiro/qt/widget/canvas.hpp
@@ -12,7 +12,7 @@ struct pCanvas : pWidget {
   auto setFocusable(bool focusable) -> void override;
   auto setGeometry(Geometry geometry) -> void;
   auto setGradient(Gradient gradient) -> void;
-  auto setIcon(const image& icon) -> void;
+  auto setIcon(const image& icon, Color padding) -> void;
   auto update() -> void;
 
   auto _rasterize() -> void;

--- a/hiro/windows/widget/canvas.cpp
+++ b/hiro/windows/widget/canvas.cpp
@@ -42,7 +42,7 @@ auto pCanvas::setGradient(Gradient gradient) -> void {
   update();
 }
 
-auto pCanvas::setIcon(const image& icon) -> void {
+auto pCanvas::setIcon(const image& icon, Color padding) -> void {
   update();
 }
 
@@ -145,7 +145,13 @@ auto pCanvas::_paint() -> void {
 
   RECT rc;
   GetClientRect(hwnd, &rc);
-  DrawThemeParentBackground(hwnd, ps.hdc, &rc);
+  Color padding = state().color;
+  if(padding.alpha() == 0) {  //GDI doesn't support real alpha fill
+    DrawThemeParentBackground(hwnd, ps.hdc, &rc);
+  } else {
+    HBRUSH hbr = CreateSolidBrush(RGB(padding.red(), padding.green(), padding.blue()));
+    FillRect(ps.hdc, &rc, hbr);
+  }
 
   BLENDFUNCTION bf{AC_SRC_OVER, 0, (BYTE)255, AC_SRC_ALPHA};
   AlphaBlend(ps.hdc, dx, dy, width, height, hdc, 0, 0, width, height, bf);

--- a/hiro/windows/widget/canvas.hpp
+++ b/hiro/windows/widget/canvas.hpp
@@ -12,7 +12,7 @@ struct pCanvas : pWidget {
   auto setFocusable(bool focusable) -> void override;
   auto setGeometry(Geometry geometry) -> void override;
   auto setGradient(Gradient gradient) -> void;
-  auto setIcon(const image& icon) -> void;
+  auto setIcon(const image& icon, Color padding) -> void;
   auto update() -> void;
 
   auto doMouseLeave() -> void override;


### PR DESCRIPTION
The bsnes window is mostly covered by the viewport, which is supposed to be black. When the window is resized, the hiro Viewport widget repaints itself, according to whatever hiro backend is in use.

However, on some platforms that's not enough. Specifically on X11, when the user resizes a window the window manager, the X server, and the application can all have different ideas about the exact window size. The X11 protocol gives each window a "default background colour", to be used by the X server to fill the blanks after the window manager has resized the window, but before the application has been able to repaint it. Because the bsnes window is *mostly* black, bsnes sets its window background colour to black, so the flickering of X-server-drawn and application-drawn content will be less obvious.

Unfortunately, it gets more complex. GTK+2 was designed around the X11 model, and so it works basically the way bsnes expects. GTK+3 was designed around the more modern compositing model, which doesn't need that "default background colour" hack, and as a result when you set the window background colour on GTK+3. that background colour is used for *everything*. Even the menu-bar, which by default draws text in a very dark grey, so you can hardly read what it says.

Perhaps there is a way to both avoid flicker on GTK+2 and not break GTK+3, but until we find it, I would rather occasional flicker on GTK+2 than permanently broken GTK+3.

Fixes #108.