### PR TITLE
target-bsnes: Do not set the window background to black.

### DIFF
--- a/bsnes/target-bsnes/presentation/presentation.cpp
+++ b/bsnes/target-bsnes/presentation/presentation.cpp
@@ -218,6 +218,10 @@ auto Presentation::create() -> void {
   iconCanvas.setDroppable();
   iconCanvas.onDrop([&](auto locations) { onDrop(locations); });
 
+  iconPadding.setColor({0, 0, 0});
+  iconPadding.setDroppable();
+  iconPadding.onDrop([&](auto locations) { onDrop(locations); });
+
   if(!settings.general.statusBar) layout.remove(statusLayout);
 
   auto font = Font().setBold();
@@ -250,7 +254,6 @@ auto Presentation::create() -> void {
   });
 
   setTitle({"bsnes v", Emulator::Version});
-  setBackgroundColor({0, 0, 0});
   resizeWindow();
   setAlignment(Alignment::Center);
 

--- a/bsnes/target-bsnes/presentation/presentation.hpp
+++ b/bsnes/target-bsnes/presentation/presentation.hpp
@@ -126,7 +126,9 @@ struct Presentation : Window {
       Viewport viewport{&viewportLayout, Size{~0, ~0}, 0};
       VerticalLayout iconLayout{&viewportLayout, Size{0, ~0}, 0};
         Canvas iconSpacer{&iconLayout, Size{144, ~0}, 0};
-        Canvas iconCanvas{&iconLayout, Size{128, 128}, 0};
+        HorizontalLayout iconHorizontal{&iconLayout, Size{144, 128}, 0};
+          Canvas iconCanvas{&iconHorizontal, Size{128, 128}, 0};
+          Canvas iconPadding{&iconHorizontal, Size{16, 128}, 0};
     HorizontalLayout statusLayout{&layout, Size{~0, StatusHeight}, 0};
       Label spacerIcon{&statusLayout, Size{8, ~0}, 0};
       Canvas statusIcon{&statusLayout, Size{16, ~0}, 0};


### PR DESCRIPTION
To resize a window on X11, the window manager tells the X11 server to change the window size, then the X11 server tells the application to paint itself, and then (eventually) the application tells the X11 server what to draw. This adds an arbitrary amount of latency to resizing, so to make things feel more responsive, the X11 server will paint any newly-exposed parts of the window with a default background colour. If it happens to be the same colour as the appplication would paint anyway, this gives resizing a much better user-experience.

Since most of bsnes' window is occupied by the viewport, which is always black, bsnes accordingly set its window background colour to black for the best resizing experience. However, this had two additional effects:

  - When no game is loaded, bsnes displays the bsnes icon in the main display area. Black canvas widgets are used as spacers to position the icon correctly, but the spacers don't cover the entire background, and the window background shines through.
  - GTK+3 draws widget transparent by default, so the background colour of the parent widget shines through child widgets. In particular, setting the window background to black makes the menu background black, even if the menu text is also a dark colour.

In order to get the menu to display properly in GTK+3 builds, we have to stop bsnes from setting the top-level window background colour, and we also have to ensure that the spacer widgets around the icon cover the entire surface of the window.

Fixes #108.
