### PR TITLE
ruby: Auto detect some dependencies on linux.

### DIFF
--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -1,3 +1,13 @@
+# function pkg_check(pkg_config_name, ruby_name)
+pkg_check = \
+  $(strip \
+    $(if $(shell pkg-config --exists $1 && echo yes), \
+      ruby += $2 \
+    , \
+      $(warning Package $1 not found, disabling driver) \
+    ) \
+  )
+
 ifeq ($(ruby),)
   ifeq ($(platform),windows)
     ruby += video.wgl video.direct3d video.directdraw video.gdi
@@ -9,12 +19,22 @@ ifeq ($(ruby),)
     ruby += input.quartz #input.carbon
   else ifeq ($(platform),linux)
     ruby += video.glx video.glx2 video.xvideo video.xshm
-    ruby += audio.oss audio.alsa audio.openal audio.pulseaudio audio.pulseaudiosimple audio.ao
-    ruby += input.sdl input.xlib input.udev
+    ruby += audio.oss audio.alsa
+    $(eval $(call pkg_check,openal,audio.openal))
+    $(eval $(call pkg_check,libpulse,audio.pulseaudio))
+    $(eval $(call pkg_check,libpulse,audio.pulseaudiosimple))
+    $(eval $(call pkg_check,ao,audio.ao))
+    ruby += input.xlib
+    $(eval $(call pkg_check,sdl2,input.sdl))
+    $(eval $(call pkg_check,udev,input.udev))
   else ifeq ($(platform),bsd)
     ruby += video.glx video.glx2 video.xvideo video.xshm
-    ruby += audio.oss audio.openal #audio.pulseaudio
-    ruby += input.sdl input.xlib
+    ruby += audio.oss
+    $(eval $(call pkg_check,openal,audio.openal))
+    $(eval $(call pkg_check,libpulse,audio.pulseaudio))
+    $(eval $(call pkg_check,libpulse,audio.pulseaudiosimple))
+    ruby += input.xlib
+    $(eval $(call pkg_check,sdl2,input.sdl))
   endif
 endif
 


### PR DESCRIPTION
For source builds its annoying and brittle having to write `sed` commands to automatically remove these from `ruby/GNUmakefile` when the dependencies are not present.

I think its better doing this directly in the build system with `pkg-config --exists`.

This will automatically detect and enable if present:
* sdl2
* openal
* pulseaudio
* libao
* udev

This also only applies to linux builds, other platforms may want to do similar, but I will leave that for people who actually use them.