### PR TITLE
Update website and copyright

### DIFF
--- a/bsnes/emulator/emulator.hpp
+++ b/bsnes/emulator/emulator.hpp
@@ -30,9 +30,9 @@ using namespace nall;
 namespace Emulator {
   static const string Name      = "bsnes";
   static const string Version   = "115";
-  static const string Copyright = "byuu et al";
+  static const string Copyright = "bsnes team";
   static const string License   = "GPLv3 or later";
-  static const string Website   = "https://byuu.org/bsnes/";
+  static const string Website   = "https://bsnes.dev";
 
   //incremented only when serialization format changes
   static const string SerializerVersion = "115";


### PR DESCRIPTION
I've registered https://bsnes.dev to be the new homepage for the project.
Screwtape and I are still working out how we're going to handle the page, but I want to get away from the old domain, and this is where we start that process.