### PR TITLE
Prevent Satellaview games smaller than 1024kb from crashing, Hide Bottom Most Scanline When Playing SGB Games & LibRetro: Allow MSU-1 SGB games to work properly

### DIFF
--- a/bsnes/heuristics/bs-memory.cpp
+++ b/bsnes/heuristics/bs-memory.cpp
@@ -26,7 +26,7 @@ auto BSMemory::manifest() const -> string {
   output.append("  label:  ", Location::prefix(location), "\n");
   output.append("  name:   ", Location::prefix(location), "\n");
   output.append("  board\n");
-  output.append(Memory{}.type("Flash").size(data.size()).content("Program").text());
+  output.append(Memory{}.type("Flash").size(0x100000).content("Program").text());
   return output;
 }
 

--- a/bsnes/target-bsnes/program/platform.cpp
+++ b/bsnes/target-bsnes/program/platform.cpp
@@ -216,7 +216,14 @@ auto Program::videoFrame(const uint16* data, uint pitch, uint width, uint height
   if(!settings.video.overscan) {
     uint multiplier = height / 240;
     data += 8 * multiplier * pitch;
-    height -= 16 * multiplier;
+	if (gameBoy.program)
+		{
+			height -= 16.1 * multiplier;
+		}
+		else
+		{
+			height -= 16 * multiplier;
+		}
   }
 
   uint outputWidth, outputHeight;

--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -700,6 +700,18 @@ RETRO_API bool retro_load_game(const retro_game_info *game)
 		}
 
 	}
+	else if (string(game->path).endsWith(".bs"))
+	{
+		const char *system_dir;
+		environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir);
+		string bs_full_path = string(system_dir, "/", "BS-X.bin").transform("\\", "/");
+		if (!file::exists(bs_full_path)) {
+			return false;
+		}
+
+		program->superFamicom.location = bs_full_path;
+		program->bsMemory.location = string(game->path);
+	}
 	else
 	{
 		program->superFamicom.location = string(game->path);

--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -663,17 +663,42 @@ RETRO_API bool retro_load_game(const retro_game_info *game)
 
 	flush_variables();
 
-	if (string(game->path).endsWith(".gb") || string(game->path).endsWith(".gbc"))
+	if (string(game->path).endsWith(".gb"))
 	{
 		const char *system_dir;
 		environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir);
-		string sgb_full_path = string(system_dir, "/", sgb_bios).transform("\\", "/");
-		if (!file::exists(sgb_full_path)) {
+		string sgb_full_path = string(game->path).transform("\\", "/");
+		string sgb_full_path2 = string(sgb_full_path).replace(".gb", ".sfc");
+		if (!file::exists(sgb_full_path2)) {
+			string sgb_full_path = string(system_dir, "/", sgb_bios).transform("\\", "/");
+			program->superFamicom.location = sgb_full_path;
+		}
+        else {
+			program->superFamicom.location = sgb_full_path2;
+		}
+		program->gameBoy.location = string(game->path);
+		if (!file::exists(program->superFamicom.location)) {
+			return false;
+		}
+	}
+	else if (string(game->path).endsWith(".gbc"))
+	{
+		const char *system_dir;
+		environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir);
+		string sgb_full_path = string(game->path).transform("\\", "/");
+		string sgb_full_path2 = string(sgb_full_path).replace(".gbc", ".sfc");
+		if (!file::exists(sgb_full_path2)) {
+			string sgb_full_path = string(system_dir, "/", sgb_bios).transform("\\", "/");
+			program->superFamicom.location = sgb_full_path;
+		}
+        else {
+			program->superFamicom.location = sgb_full_path2;
+		}
+		program->gameBoy.location = string(game->path);
+		if (!file::exists(program->superFamicom.location)) {
 			return false;
 		}
 
-		program->superFamicom.location = sgb_full_path;
-		program->gameBoy.location = string(game->path);
 	}
 	else
 	{

--- a/bsnes/target-libretro/libretro.cpp
+++ b/bsnes/target-libretro/libretro.cpp
@@ -663,12 +663,12 @@ RETRO_API bool retro_load_game(const retro_game_info *game)
 
 	flush_variables();
 
-	if (string(game->path).endsWith(".gb"))
+	if (string(game->path).endsWith(".gb") || string(game->path).endsWith(".gbc"))
 	{
 		const char *system_dir;
 		environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir);
 		string sgb_full_path = string(game->path).transform("\\", "/");
-		string sgb_full_path2 = string(sgb_full_path).replace(".gb", ".sfc");
+		string sgb_full_path2 = string(sgb_full_path).replace(".gbc", ".sfc").replace(".gb", ".sfc");
 		if (!file::exists(sgb_full_path2)) {
 			string sgb_full_path = string(system_dir, "/", sgb_bios).transform("\\", "/");
 			program->superFamicom.location = sgb_full_path;
@@ -680,25 +680,6 @@ RETRO_API bool retro_load_game(const retro_game_info *game)
 		if (!file::exists(program->superFamicom.location)) {
 			return false;
 		}
-	}
-	else if (string(game->path).endsWith(".gbc"))
-	{
-		const char *system_dir;
-		environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir);
-		string sgb_full_path = string(game->path).transform("\\", "/");
-		string sgb_full_path2 = string(sgb_full_path).replace(".gbc", ".sfc");
-		if (!file::exists(sgb_full_path2)) {
-			string sgb_full_path = string(system_dir, "/", sgb_bios).transform("\\", "/");
-			program->superFamicom.location = sgb_full_path;
-		}
-        else {
-			program->superFamicom.location = sgb_full_path2;
-		}
-		program->gameBoy.location = string(game->path);
-		if (!file::exists(program->superFamicom.location)) {
-			return false;
-		}
-
 	}
 	else if (string(game->path).endsWith(".bs"))
 	{

--- a/bsnes/target-libretro/program.cpp
+++ b/bsnes/target-libretro/program.cpp
@@ -243,7 +243,14 @@ auto Program::videoFrame(const uint16* data, uint pitch, uint width, uint height
 	{
 		uint multiplier = height / 240;
 		data += 8 * (pitch >> 1) * multiplier;
-		height -= 16 * multiplier;
+		if (program->gameBoy.program)
+		{
+			height -= 16.1 * multiplier;
+		}
+		else
+		{
+			height -= 16 * multiplier;
+		}
 	}
 	video_cb(data, width, height, pitch);
 }


### PR DESCRIPTION
This change allows for a SGB boot rom with the same name as a SGB rom to be loaded from the same folder, which allows for MSU-1 enhanced SGB games to work without having to rely on the subsystem menu.
If it fails to load a SGB boot rom from the same folder, it will first revert to the already implemented method of loading the boot rom from the system directory and etc.