### PR TITLE
hiro: Try to fix freebsd Cirrus CI build failure.

### DIFF
--- a/hiro/GNUmakefile
+++ b/hiro/GNUmakefile
@@ -38,6 +38,9 @@ ifneq ($(filter $(platform),linux bsd),)
   ifeq ($(hiro),gtk2)
     hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell pkg-config --cflags gtk+-2.0 gtksourceview-2.0)
     hiro.options = -L/usr/local/lib -lX11 $(shell pkg-config --libs gtk+-2.0 gtksourceview-2.0)
+    ifeq ($(platform),bsd)
+      hiro.options += -lc++
+    endif
   endif
 
   ifeq ($(hiro),gtk3)
@@ -70,7 +73,7 @@ $(object.path)/hiro-$(hiro).o: $(hiro.path)/hiro.cpp
 	$(if $(filter qt%,$(hiro)),$(info Compiling $(hiro.path)/qt/qt.moc ...))
 	$(if $(filter qt%,$(hiro)),@$(moc) -i -o $(hiro.path)/qt/qt.moc $(hiro.path)/qt/qt.hpp)
 	$(info Compiling $< ...)
-	@$(compiler) $(hiro.flags) $(flags) $(flags.deps) -c $< -o $@
+	@$(compiler) $(hiro.flags) $(flags) $(flags.deps) $(hiro.options) -c $< -o $@
 
 $(object.path)/hiro-resource.o: $(hiro.resource)
 	$(info Compiling $< ...)


### PR DESCRIPTION
Tries to fix the Cirrus CI build failure for FreeBSD. I am doing this blind so lets see what CI says...
```
ld-elf.so.1: /usr/local/libexec/gcc8/gcc/x86_64-portbld-freebsd12.2/8.4.0/cc1plus: Undefined symbol "fputs_unlocked@FBSD_1.6"
gmake: *** [../hiro/GNUmakefile:89: obj/hiro-gtk2.o] Error 1
gmake: Leaving directory '/tmp/cirrus-ci-build/bsnes'
```