### PR TITLE
Update the FreeBSD image to fix a build failure.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,7 +24,7 @@ linux-x86_64-binaries_task:
 
 freebsd-x86_64-binaries_task:
     freebsd_instance:
-        image_family: freebsd-12-1
+        image_family: freebsd-12-2
 
     setup_script:
         - pkg install --yes gmake gdb gcc8 pkgconf sdl2 openal-soft gtksourceview2 libXv zip


### PR DESCRIPTION
Apparently Ports only supports the latest stable release, not earlier releases in the 12.x family.