### PR TITLE
Add mode presets for accuracy and performance mode to simplify enhancements settings

### DIFF
--- a/bsnes/target-bsnes/settings/enhancements.cpp
+++ b/bsnes/target-bsnes/settings/enhancements.cpp
@@ -133,6 +133,54 @@ auto EnhancementSettings::create() -> void {
   }).setChecked(settings.emulator.hack.hotfixes).onToggle([&] {
     settings.emulator.hack.hotfixes = hotfixes.checked();
   });
-
-  note.setText("Note: some settings do not take effect until after reloading games.");
+  
+  
+  ppuModeLabel.setText("Mode Presets:").setFont(Font().setBold());
+  ppuModeRequirements.setText(
+    "Accuracy Mode: Maximum hardware accuracy, disables performance shortcuts and all enhancements.\n"
+    "Performance Mode: Best compromise between hardware accuracy and performance."
+  );
+  accuracyMode.setText("Accuracy Mode").onActivate([&] {
+    runAhead0.setChecked(); settings.emulator.runAhead.frames = 0;
+    cpuClock.setPosition(0); cpuClock.doChange();
+    sa1Clock.setPosition(0); sa1Clock.doChange();
+    sfxClock.setPosition(0); sfxClock.doChange();
+    fastPPU.setChecked(false).doToggle();
+    fastDSP.setChecked(false).doToggle();
+    cubicInterpolation.setChecked(false).doToggle();
+    coprocessorDelayedSyncOption.setChecked(false).doToggle();
+    coprocessorPreferHLEOption.setChecked(false).doToggle();
+    hotfixes.setChecked(false).doToggle();
+	
+    if(!emulator->loaded()) return;
+    MessageDialog().setAlignment(settingsWindow).setTitle("Success").setText({
+      "Accuracy Mode applied.\n"
+      "You must reload the game in order for all changes to take effect."
+    }).information();
+  });
+	
+  performanceMode.setText("Performance Mode").onActivate([&] {
+    runAhead0.setChecked(); settings.emulator.runAhead.frames = 0;
+    cpuClock.setPosition(0); cpuClock.doChange();
+    sa1Clock.setPosition(0); sa1Clock.doChange();
+    sfxClock.setPosition(0); sfxClock.doChange();
+    fastPPU.setChecked(true).doToggle();
+    deinterlace.setChecked(true).doToggle();
+    noSpriteLimit.setChecked(false).doToggle();
+    mode7Scale.item(0).setSelected(); emulator->configure("Hacks/PPU/Mode7/Scale", settings.emulator.hack.ppu.mode7.scale = 1);
+    mode7Perspective.setChecked(true).doToggle();
+    mode7Supersample.setChecked(false).doToggle();
+    mode7Mosaic.setChecked(true).doToggle();
+    fastDSP.setChecked(true).doToggle();
+    cubicInterpolation.setChecked(false).doToggle();
+    coprocessorDelayedSyncOption.setChecked(true).doToggle();
+    coprocessorPreferHLEOption.setChecked(false).doToggle();
+    hotfixes.setChecked(true).doToggle();
+    
+    if(!emulator->loaded()) return;
+    MessageDialog().setAlignment(settingsWindow).setTitle("Success").setText({
+      "Performance Mode applied.\n"
+      "You must reload the game in order for all changes to take effect."
+    }).information();
+  });
 }

--- a/bsnes/target-bsnes/settings/enhancements.cpp
+++ b/bsnes/target-bsnes/settings/enhancements.cpp
@@ -50,7 +50,7 @@ auto EnhancementSettings::create() -> void {
     emulator->configure("Hacks/SuperFX/Overclock", settings.emulator.hack.superfx.overclock);
     sfxValue.setText({settings.emulator.hack.superfx.overclock, "%"});
   }).doChange();
-  note.setText("Note: Enabling overclocking will break games, cause bugs and reduce performance.");
+  note.setText("Note: Overclocking will break games, cause bugs and reduce performance.");
   overclockingSpacer.setColor({192, 192, 192});
 
   ppuLabel.setText("PPU (video)").setFont(Font().setBold());

--- a/bsnes/target-bsnes/settings/enhancements.cpp
+++ b/bsnes/target-bsnes/settings/enhancements.cpp
@@ -50,7 +50,7 @@ auto EnhancementSettings::create() -> void {
     emulator->configure("Hacks/SuperFX/Overclock", settings.emulator.hack.superfx.overclock);
     sfxValue.setText({settings.emulator.hack.superfx.overclock, "%"});
   }).doChange();
-
+  note.setText("Note: Enabling overclocking will break games, cause bugs and reduce performance.");
   overclockingSpacer.setColor({192, 192, 192});
 
   ppuLabel.setText("PPU (video)").setFont(Font().setBold());
@@ -133,8 +133,8 @@ auto EnhancementSettings::create() -> void {
   }).setChecked(settings.emulator.hack.hotfixes).onToggle([&] {
     settings.emulator.hack.hotfixes = hotfixes.checked();
   });
-  
-  
+  hotfixesSpacer.setColor({192, 192, 192});
+
   ppuModeLabel.setText("Mode Presets:").setFont(Font().setBold());
   ppuModeRequirements.setText(
     "Accuracy Mode: Maximum hardware accuracy, disables performance shortcuts and all enhancements.\n"
@@ -142,28 +142,28 @@ auto EnhancementSettings::create() -> void {
   );
   accuracyMode.setText("Accuracy Mode").onActivate([&] {
     runAhead0.setChecked(); settings.emulator.runAhead.frames = 0;
-    cpuClock.setPosition(0); cpuClock.doChange();
-    sa1Clock.setPosition(0); sa1Clock.doChange();
-    sfxClock.setPosition(0); sfxClock.doChange();
+    cpuClock.setPosition(0).doChange();
+    sa1Clock.setPosition(0).doChange();
+    sfxClock.setPosition(0).doChange();
     fastPPU.setChecked(false).doToggle();
     fastDSP.setChecked(false).doToggle();
     cubicInterpolation.setChecked(false).doToggle();
     coprocessorDelayedSyncOption.setChecked(false).doToggle();
     coprocessorPreferHLEOption.setChecked(false).doToggle();
     hotfixes.setChecked(false).doToggle();
-	
+
     if(!emulator->loaded()) return;
     MessageDialog().setAlignment(settingsWindow).setTitle("Success").setText({
       "Accuracy Mode applied.\n"
       "You must reload the game in order for all changes to take effect."
     }).information();
   });
-	
+
   performanceMode.setText("Performance Mode").onActivate([&] {
     runAhead0.setChecked(); settings.emulator.runAhead.frames = 0;
-    cpuClock.setPosition(0); cpuClock.doChange();
-    sa1Clock.setPosition(0); sa1Clock.doChange();
-    sfxClock.setPosition(0); sfxClock.doChange();
+    cpuClock.setPosition(0).doChange();
+    sa1Clock.setPosition(0).doChange();
+    sfxClock.setPosition(0).doChange();
     fastPPU.setChecked(true).doToggle();
     deinterlace.setChecked(true).doToggle();
     noSpriteLimit.setChecked(false).doToggle();
@@ -176,7 +176,7 @@ auto EnhancementSettings::create() -> void {
     coprocessorDelayedSyncOption.setChecked(true).doToggle();
     coprocessorPreferHLEOption.setChecked(false).doToggle();
     hotfixes.setChecked(true).doToggle();
-    
+
     if(!emulator->loaded()) return;
     MessageDialog().setAlignment(settingsWindow).setTitle("Success").setText({
       "Performance Mode applied.\n"

--- a/bsnes/target-bsnes/settings/settings.hpp
+++ b/bsnes/target-bsnes/settings/settings.hpp
@@ -349,6 +349,9 @@ public:
     Label cpuLabel{&overclockingLayout, Size{0, 0}};
     Label cpuValue{&overclockingLayout, Size{50_sx, 0}};
     HorizontalSlider cpuClock{&overclockingLayout, Size{~0, 0}};
+  //
+  Widget spacer{this, Size{~0, ~0}};
+    Label note{this, Size{~0, 0}};
   Canvas overclockingSpacer{this, Size{~0, 1}};
   //
     Label sa1Label{&overclockingLayout, Size{0, 0}};
@@ -385,10 +388,8 @@ public:
   Canvas coprocessorSpacer{this, Size{~0, 1}};
   //
   Label gameLabel{this, Size{~0, 0}, 2};
-  CheckLabel hotfixes{this, Size{0, 0}};
-  //
-  Widget spacer{this, Size{~0, ~0}};
-  Label note{this, Size{~0, 0}};
+    CheckLabel hotfixes{this, Size{0, 0}};
+  Canvas hotfixesSpacer{this, Size{~0, 1}};
   //
   Label ppuModeLabel{this, Size{~0, 0}, 0};
   Label ppuModeRequirements{this, Size{~0, 0}};

--- a/bsnes/target-bsnes/settings/settings.hpp
+++ b/bsnes/target-bsnes/settings/settings.hpp
@@ -389,6 +389,12 @@ public:
   //
   Widget spacer{this, Size{~0, ~0}};
   Label note{this, Size{~0, 0}};
+  //
+  Label ppuModeLabel{this, Size{~0, 0}, 0};
+  Label ppuModeRequirements{this, Size{~0, 0}};
+  HorizontalLayout modeLayout{this, Size{~0, 0}};
+    Button accuracyMode{&modeLayout, Size{0, 0}};
+    Button performanceMode{&modeLayout, Size{0, 0}};
 };
 
 struct CompatibilitySettings : VerticalLayout {


### PR DESCRIPTION
https://user-images.githubusercontent.com/79463574/108725701-ed936900-7526-11eb-9216-dfb4935aad94.mp4

Fixes: https://github.com/bsnes-emu/bsnes/issues/113

When a game is loaded, you will get an information that you should reload the game in order for all changes to take effect. If no game is loaded, you will not see this, because the changes will take effect immediately. It's working really good and I think with that user will better unterstand what they have to enable for a good gaming experience.

Other than that, I'm not sure whats the best way to describe these two mode presets, but I don't think something like:
**Performance mode: Maximum speed, [...]**
is right, because it isn't _just_ about speed, that's why something like "Prefer HLE" is disabled. We should come up with something appropriate, so people want to use this mode by default. You can decide what's the best way to do this.

Thanks again for your help, Screwtape. :)

**Edit:** 
- added hotfixesSpacer
- added overclocking note
- minor adjustments

![image](https://user-images.githubusercontent.com/79463574/109158371-90d8be00-7773-11eb-8545-8826e30b93ec.png)


