### PR TITLE
hiro: Remove gtksourceview dependency.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ linux-x86_64-binaries_task:
         image: ubuntu:latest
 
     setup_script:
-        - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential libgtk2.0-dev libpulse-dev mesa-common-dev libgtksourceview2.0-dev libcairo2-dev libsdl2-dev libxv-dev libao-dev libopenal-dev libudev-dev zip
+        - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential libgtk2.0-dev libpulse-dev mesa-common-dev libcairo2-dev libsdl2-dev libxv-dev libao-dev libopenal-dev libudev-dev zip
 
     compile_script:
         - make -C bsnes local=false
@@ -27,7 +27,7 @@ freebsd-x86_64-binaries_task:
         image_family: freebsd-12-2
 
     setup_script:
-        - pkg install --yes gmake gdb gcc8 pkgconf sdl2 openal-soft gtksourceview2 libXv zip
+        - pkg install --yes gmake gdb gcc8 pkgconf sdl2 openal-soft gtk2 libXv zip
 
     compile_script:
         - gmake -C bsnes local=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         sudo apt-get update -y -qq
         sudo apt-get install \
-          libgtk2.0-dev libpulse-dev mesa-common-dev libgtksourceview2.0-dev libcairo2-dev \
+          libgtk2.0-dev libpulse-dev mesa-common-dev libcairo2-dev \
           libsdl2-dev libxv-dev libao-dev libopenal-dev libudev-dev
     - name: Make
       run: make -j4 -C bsnes local=false

--- a/hiro/GNUmakefile
+++ b/hiro/GNUmakefile
@@ -9,13 +9,13 @@ ifeq ($(platform),windows)
   endif
 
   ifeq ($(hiro),gtk2)
-    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell pkg-config --cflags gtk+-2.0 gtksourceview-2.0)
-    hiro.options = $(shell pkg-config --libs gtk+-2.0 gtksourceview-2.0)
+    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell pkg-config --cflags gtk+-2.0) -Wno-deprecated-declarations
+    hiro.options = $(shell pkg-config --libs gtk+-2.0)
   endif
 
   ifeq ($(hiro),gtk3)
-    hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell pkg-config --cflags gtk+-3.0 gtksourceview-3.0) -Wno-deprecated-declarations
-    hiro.options = $(shell pkg-config --libs gtk+-3.0 gtksourceview-3.0)
+    hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell pkg-config --cflags gtk+-3.0) -Wno-deprecated-declarations
+    hiro.options = $(shell pkg-config --libs gtk+-3.0)
   endif
 endif
 
@@ -26,7 +26,7 @@ ifeq ($(platform),macos)
 
   ifeq ($(hiro),cocoa)
     hiro.flags   = $(flags.objcpp) -w -DHIRO_COCOA
-    hiro.options = -framework Cocoa -framework Carbon -framework Security
+    hiro.options = -framework Cocoa -framework Carbon -framework IOKit -framework Security
   endif
 endif
 
@@ -36,11 +36,23 @@ ifneq ($(filter $(platform),linux bsd),)
   endif
 
   ifeq ($(hiro),gtk2)
-    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell pkg-config --cflags gtk+-2.0 gtksourceview-2.0)
+    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell pkg-config --cflags gtk+-2.0) -Wno-deprecated-declarations
+    hiro.options = -L/usr/local/lib -lX11 $(shell pkg-config --libs gtk+-2.0)
+  endif
+
+  ifeq ($(hiro),gtk2-se)
+    flags       += -DHiro_SourceEdit
+    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell pkg-config --cflags gtk+-2.0 gtksourceview-2.0) -Wno-deprecated-declarations
     hiro.options = -L/usr/local/lib -lX11 $(shell pkg-config --libs gtk+-2.0 gtksourceview-2.0)
   endif
 
   ifeq ($(hiro),gtk3)
+    hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell pkg-config --cflags gtk+-3.0) -Wno-deprecated-declarations
+    hiro.options = -L/usr/local/lib -lX11 $(shell pkg-config --libs gtk+-3.0)
+  endif
+
+  ifeq ($(hiro),gtk3-se)
+    flags       += -DHiro_SourceEdit
     hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell pkg-config --cflags gtk+-3.0 gtksourceview-3.0) -Wno-deprecated-declarations
     hiro.options = -L/usr/local/lib -lX11 $(shell pkg-config --libs gtk+-3.0 gtksourceview-3.0)
   endif
@@ -69,11 +81,11 @@ hiro.objects := \
 $(object.path)/hiro-$(hiro).o: $(hiro.path)/hiro.cpp
 	$(if $(filter qt%,$(hiro)),$(info Compiling $(hiro.path)/qt/qt.moc ...))
 	$(if $(filter qt%,$(hiro)),@$(moc) -i -o $(hiro.path)/qt/qt.moc $(hiro.path)/qt/qt.hpp)
-	$(info Compiling $< ...)
+	$(info Compiling $(subst ../,,$<) ...)
 	@$(compiler) $(hiro.flags) $(flags) $(flags.deps) -c $< -o $@
 
 $(object.path)/hiro-resource.o: $(hiro.resource)
-	$(info Compiling $< ...)
+	$(info Compiling $(subst ../,,$<) ...)
 	@$(windres) $< $@
 
 hiro.verbose:

--- a/hiro/components.hpp
+++ b/hiro/components.hpp
@@ -66,7 +66,7 @@
 #define Hiro_ProgressBar
 #define Hiro_RadioButton
 #define Hiro_RadioLabel
-#define Hiro_SourceEdit
+//#define Hiro_SourceEdit  //added via GNUmakefile
 #define Hiro_TabFrame
 #define Hiro_TableView
 #define Hiro_TextEdit


### PR DESCRIPTION
The GTK2 and GTK3 backends for hiro implement a source-code editing widget based on gtksourceview. gtksourceview2 in particular is quite old and unmaintained, and Linux distros are keen to drop it, so removing the dependency helps keep bsnes portable to future platforms -- especially since bsnes doesn't *use* the source-editing widget anywhere. It's only used by Near's text-editor, amethyst.

We could just rip out the gtksourceview-related code and be done with it, but since Near is still around and still working on his own copy of hiro, I asked him to contribute his implementation so that it will be easier to merge any future changes too.

This adds two new hiro targets, "gtk2-se" and "gtk3-se" which include the source-code editing widget and the gtksourceview dependency. Since bsnes defaults to "gtk2" (without the dependency) we no longer need that package installed to build bsnes.

Fixes #137.
