### PR TITLE
hiro: Disable padding for the GTK+3 backend.

### DIFF
--- a/hiro/gtk/application.cpp
+++ b/hiro/gtk/application.cpp
@@ -169,7 +169,18 @@ auto pApplication::initialize() -> void {
     widget_class "*.<GtkNotebook>.<GtkHBox>.<GtkButton>" style "HiroTabFrameCloseButton"
   )");
   #elif HIRO_GTK==3
-  //TODO: is there any alternative here with GTK3?
+  GtkCssProvider *provider;
+  GdkScreen *screen;
+
+  provider = gtk_css_provider_new();
+  gtk_css_provider_load_from_data(GTK_CSS_PROVIDER (provider), R"(
+    scale { padding-top: 0; padding-bottom: 0; }
+    entry { min-height: 0; }
+    button { padding: 0; }
+  )", -1, NULL);
+
+  screen = gdk_screen_get_default();
+  gtk_style_context_add_provider_for_screen(screen, GTK_STYLE_PROVIDER (provider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
   #endif
 
   pKeyboard::initialize();


### PR DESCRIPTION
GTK+3 is designed for automatic layout, where widgets are automatically sized and positioned according to the size of their contents. However, hiro has to be compatible with Windows, which lacks an automatic layout system, so hiro apps tend to position widgets manually.

Unfortunately, the GTK+3 default theme uses much bigger widgets than GTK+2 or Windows, so hiro apps using the GTK+3 backend tend to have ugly, overlapping widgets. To make GTK+3 behave more like other hiro targets, we add custom CSS and override the default theme at runtime.

Fixes #168.

### Comparison

How the Drivers pane currently looks in GTK+2:

![The bsnes Drivers pane, all nicely aligned](https://user-images.githubusercontent.com/1450918/113266968-8d5fc600-9321-11eb-9201-f57501965381.png)

How the Drivers pane currently looks in GTK+3:

![The bsnes Drivers pane, all blobby and overlapping](https://user-images.githubusercontent.com/1450918/113267145-bd0ece00-9321-11eb-97a0-02296efaf026.png)

How the Drivers pane looks with this PR:

![The bsnes Drivers pane, looking much better](https://user-images.githubusercontent.com/1450918/113267203-cd26ad80-9321-11eb-83b1-a861bd9e2007.png)

### Todo

There's a status-bar at the bottom of the Settings window whose top overlaps the bottom of the pane list, and the bottom widgets of each pane. Unfortunately, they sometimes have some Z-fighting and I'm not sure why. I can't see any CSS that would force the status bar to be tall either. Maybe we can figure that out later, though - this is already a nice improvement over the current state of the GTK+3 build.