### PR TITLE
Auto joypad cleanup

### DIFF
--- a/bsnes/sfc/cpu/cpu.hpp
+++ b/bsnes/sfc/cpu/cpu.hpp
@@ -118,8 +118,6 @@ private:
     bool hdmaPending = 0;
     bool hdmaMode = 0;  //0 = init, 1 = run
 
-    bool autoJoypadActive = 0;
-    bool autoJoypadLatch = 0;
     uint autoJoypadCounter = 33;  //state machine; 4224 / 128 = 33 (inactive)
   } status;
 

--- a/bsnes/sfc/cpu/io.cpp
+++ b/bsnes/sfc/cpu/io.cpp
@@ -134,9 +134,9 @@ auto CPU::writeCPU(uint addr, uint8 data) -> void {
     controllerPort2.device->latch(data & 1);
     return;
 
-  //todo: it is not known what happens when writing to this register during auto-joypad polling
   case 0x4200:  //NMITIMEN
     io.autoJoypadPoll = data & 1;
+    if(!io.autoJoypadPoll) status.autoJoypadCounter = 33; // Disable auto-joypad read
     nmitimenUpdate(data);
     return;
 

--- a/bsnes/sfc/cpu/serialization.cpp
+++ b/bsnes/sfc/cpu/serialization.cpp
@@ -43,8 +43,6 @@ auto CPU::serialize(serializer& s) -> void {
   s.integer(status.hdmaPending);
   s.integer(status.hdmaMode);
 
-  s.integer(status.autoJoypadActive);
-  s.integer(status.autoJoypadLatch);
   s.integer(status.autoJoypadCounter);
 
   s.integer(io.wramAddress);


### PR DESCRIPTION
Jonas Quinn refactored higan's auto-joypad polling in https://github.com/higan-emu/higan/commit/e422ddc7293b10aae8a1935d4c7f96aeb8445430, then Asura re-implemented those changes for bsnes in 39c37ec. A bug was found in bsnes, fixed in 4f7a269, and Jonas Quinn ported the bsnes version of the code back to higan in https://github.com/higan-emu/higan/commit/9a625c545ca89b094d5c1da40bbfa5d07156a4aa.

In the process of that (back?) port, Jonas discovered that the `autoJoypadActive` and `autoJoypadLatch` variables were no longer actually being used in bsnes. Also, Jonas' original patch taught higan what happens when auto-joypad polling is disabled while active, and that detail had not made it across to bsnes before.

With these changes, bsnes and higan should once again be equally accurate emulators.