### PR TITLE
Fix critical undefined bit-shift length operation

### DIFF
--- a/nall/primitives/bit-range.hpp
+++ b/nall/primitives/bit-range.hpp
@@ -58,7 +58,8 @@ template<int Precision, int Lo, int Hi> struct BitRange<Precision, Lo, Hi> {
   }
 
   template<typename T> inline auto& operator=(const T& source) {
-    target = target & ~mask | source << shift & mask;
+    type value = source;
+    target = target & ~mask | value << shift & mask;
     return *this;
   }
 
@@ -105,17 +106,20 @@ template<int Precision, int Lo, int Hi> struct BitRange<Precision, Lo, Hi> {
   }
 
   template<typename T> inline auto& operator&=(const T& source) {
-    target = target & (~mask | source << shift & mask);
+    type value = source;
+    target = target & (~mask | value << shift & mask);
     return *this;
   }
 
   template<typename T> inline auto& operator^=(const T& source) {
-    target = target ^ source << shift & mask;
+    type value = source;
+    target = target ^ value << shift & mask;
     return *this;
   }
 
   template<typename T> inline auto& operator|=(const T& source) {
-    target = target | source << shift & mask;
+    type value = source;
+    target = target | value << shift & mask;
     return *this;
   }
 
@@ -185,7 +189,8 @@ template<int Precision> struct BitRange<Precision> {
   }
 
   template<typename T> inline auto& operator=(const T& source) {
-    target = target & ~mask | source << shift & mask;
+    type value = source;
+    target = target & ~mask | value << shift & mask;
     return *this;
   }
 
@@ -232,17 +237,20 @@ template<int Precision> struct BitRange<Precision> {
   }
 
   template<typename T> inline auto& operator&=(const T& source) {
-    target = target & (~mask | source << shift & mask);
+    type value = source;
+    target = target & (~mask | value << shift & mask);
     return *this;
   }
 
   template<typename T> inline auto& operator^=(const T& source) {
-    target = target ^ source << shift & mask;
+    type value = source;
+    target = target ^ value << shift & mask;
     return *this;
   }
 
   template<typename T> inline auto& operator|=(const T& source) {
-    target = target | source << shift & mask;
+    type value = source;
+    target = target | value << shift & mask;
     return *this;
   }
 


### PR DESCRIPTION
Natural/Integer<T>.bit() (BitRange) was shifting by whatever type the source was to match the target bit length.
But this breaks when the target type is u64/s64 and the source type is u32/s32 or smaller. Shifting by >=32 becomes undefined behavior.
We have to cast the input source to the target type first, so that the source<<shift result is valid.
This is safe here regardless of source's signedness, because it's only used in =, &=, ^=, |= operations.

Cherry-picked from https://github.com/higan-emu/higan/pull/174/files