### PR TITLE
Fix vector<T>::acquire() arguments

### DIFF
--- a/nall/vector.hpp
+++ b/nall/vector.hpp
@@ -45,7 +45,7 @@ struct vector_base {
 
   //memory.hpp
   auto reset() -> void;
-  auto acquire(const T* data, uint64_t size, uint64_t capacity = 0) -> void;
+  auto acquire(T* data, uint64_t size, uint64_t capacity = 0) -> void;
   auto release() -> T*;
 
   auto reserveLeft(uint64_t capacity) -> bool;

--- a/nall/vector/memory.hpp
+++ b/nall/vector/memory.hpp
@@ -19,7 +19,7 @@ template<typename T> auto vector<T>::reset() -> void {
 
 //acquire ownership of allocated memory
 
-template<typename T> auto vector<T>::acquire(const T* data, uint64_t size, uint64_t capacity) -> void {
+template<typename T> auto vector<T>::acquire(T* data, uint64_t size, uint64_t capacity) -> void {
   reset();
   _pool = data;
   _size = size;


### PR DESCRIPTION
This would fail to compile previously because `_pool`, which is of type `T*`, is assigned a variable of type `const T*` which results in a compiler error.
Note that this does not affect bsnes at all because this function is unused.