### PR TITLE
Add a link to the official Discord.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Links
 -----
 
   - [Official git repository](https://github.com/bsnes-emu/bsnes)
+  - [Official Discord](https://discord.gg/B27hf27ZVf)
 
 Nightly Builds
 --------------


### PR DESCRIPTION
With Near's death, we no longer have access to update https://bsnes.dev, so we'll need to put links in the README now.