### PR TITLE
Fix build failure on UCRT mingw64

### DIFF
--- a/nall/windows/guard.hpp
+++ b/nall/windows/guard.hpp
@@ -5,12 +5,16 @@
 #define interface WindowsInterface
 
 #undef UNICODE
+#undef WINVER
 #undef WIN32_LEAN_AND_MEAN
+#undef _WIN32_WINNT
 #undef NOMINMAX
 #undef PATH_MAX
 
 #define UNICODE
+#define WINVER 0x0601
 #define WIN32_LEAN_AND_MEAN
+#define _WIN32_WINNT WINVER
 #define NOMINMAX
 #define PATH_MAX 260
 

--- a/nall/windows/guard.hpp
+++ b/nall/windows/guard.hpp
@@ -5,20 +5,12 @@
 #define interface WindowsInterface
 
 #undef UNICODE
-#undef WINVER
-#undef WIN32_LEAN_AND_LEAN
-#undef _WIN32_WINNT
-#undef _WIN32_IE
-#undef __MSVCRT_VERSION__
+#undef WIN32_LEAN_AND_MEAN
 #undef NOMINMAX
 #undef PATH_MAX
 
 #define UNICODE
-#define WINVER 0x0601
 #define WIN32_LEAN_AND_MEAN
-#define _WIN32_WINNT WINVER
-#define _WIN32_IE WINVER
-#define __MSVCRT_VERSION__ WINVER
 #define NOMINMAX
 #define PATH_MAX 260
 


### PR DESCRIPTION
closes #198.

Note that `#define __MSVCRT_VERSION__ WINVER` is the only thing that broke the build, but I've removed the others regardless because
1. it doesn't feel right to define some of these and not others
2. Looks like they're bound to cause issues in the future as well

Note that the resulting binary *does* change after removing `#define _WIN32_IE WINVER`... don't ask me why, I genuinely have no idea why the internet explorer is of any relevancy here. Chose to ignore and move on 👍 