### PR TITLE
nall: File timestamp fix for OpenBSD and DragonFly BSD, add DragonFly BSD to PLATFORM_BSD definition

### DIFF
--- a/nall/inode.hpp
+++ b/nall/inode.hpp
@@ -82,6 +82,12 @@ struct inode {
     #if defined(PLATFORM_WINDOWS)
     //on Windows, the last status change time (ctime) holds the file creation time instead
     case time::create: return data.st_ctime;
+    #elif defined(__OpenBSD__)
+    // OpenBSD is a special case that must be handled separately from other BSDs
+    case time::create: return min((uint)data.__st_birthtime, (uint)data.st_mtime);
+    #elif defined (__DragonFly__)
+    // DragonFly BSD does not support file creation time, use modified time instead
+    case time::create: return data.st_mtime;
     #elif defined(PLATFORM_BSD) || defined(PLATFORM_MACOS)
     //st_birthtime may return -1 or st_atime if it is not supported by the file system
     //the best that can be done in this case is to return st_mtime if it's older

--- a/nall/intrinsics.hpp
+++ b/nall/intrinsics.hpp
@@ -98,7 +98,7 @@ namespace nall {
   constexpr auto platform() -> Platform { return Platform::Linux; }
   constexpr auto api() -> API { return API::Posix; }
   constexpr auto display() -> DisplayServer { return DisplayServer::Xorg; }
-#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined (__DragonFly__)
   #define PLATFORM_BSD
   #define API_POSIX
   #define DISPLAY_XORG


### PR DESCRIPTION
This is a manual backport of this commit from the upstream `nall` repository:
https://github.com/higan-emu/nall/commit/c673bd802e84050d83cb977955550947dccf9aef

Since the copy of `nall` in `bsnes` has diverged from the upstream repository, simply importing upstream `nall` is not possible without some changes deep in the `bsnes` codebase. Until those changes happen, this commit gives us out of the box OpenBSD support, while also paving the way for out of the box support for DragonFly.