### PR TITLE
Allow Haiku build of libretro target

### DIFF
--- a/bsnes/target-libretro/GNUmakefile
+++ b/bsnes/target-libretro/GNUmakefile
@@ -19,6 +19,8 @@ obj/libretro.o: target-libretro/libretro.cpp
 all: $(objects)
 ifeq ($(platform),linux)
 	$(strip $(compiler) -o out/$(name).so -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T -lgomp -Wl,-Bdynamic $(options))
+else ifeq ($(platform),haiku)
+	$(strip $(compiler) -o out/$(name).so -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T -lgomp -Wl,-Bdynamic $(options))
 else ifeq ($(platform),windows)
 	$(strip $(compiler) -o out/$(name).dll -shared $(objects) -Wl,--no-undefined -Wl,--version-script=target-libretro/link.T -lgomp -Wl,-Bdynamic $(options))
 else ifeq ($(platform),macos)

--- a/nall/GNUmakefile
+++ b/nall/GNUmakefile
@@ -32,6 +32,8 @@ ifeq ($(platform),)
     platform := linux
   else ifneq ($(findstring BSD,$(uname)),)
     platform := bsd
+  else ifneq ($(findstring Haiku,$(uname)),)
+    platform := haiku
   else
     $(error unknown platform, please specify manually.)
   endif
@@ -137,6 +139,11 @@ ifeq ($(platform),bsd)
   options += -Wl,-rpath=/usr/local/lib
   options += -Wl,-rpath=/usr/local/lib/gcc8
   options += -lstdc++ -lm
+endif
+
+# haiku settings
+ifeq ($(platform),haiku)
+  options += -lroot
 endif
 
 # threading support

--- a/nall/directory.hpp
+++ b/nall/directory.hpp
@@ -267,19 +267,19 @@ inline auto directory::copy(const string& source, const string& target) -> bool 
   }
 #else
   inline auto directoryIsFolder(DIR* dp, struct dirent* ep) -> bool {
-#if defined(PLATFORM_HAIKU)
-    struct stat sp = {0};
-    stat(ep->d_name, &sp);
-    if S_ISDIR(sp.st_mode) return true;
-    if (S_ISLNK(sp.st_mode) || not S_ISREG(sp.st_mode)) {
-      fstatat(dirfd(dp), ep->d_name, &sp, 0);
-      return S_ISDIR(sp.st_mode);
-    }
-#else // not PLATFORM_HAIKU
+#if defined(PLATFORM_MACOS) || defined(PLATFORM_LINUX) || defined(PLATFORM_BSD)
     if(ep->d_type == DT_DIR) return true;
     if(ep->d_type == DT_LNK || ep->d_type == DT_UNKNOWN) {
       //symbolic links must be resolved to determine type
       struct stat sp = {0};
+      fstatat(dirfd(dp), ep->d_name, &sp, 0);
+      return S_ISDIR(sp.st_mode);
+    }
+#else // strictly POSIX systems
+    struct stat sp = {0};
+    stat(ep->d_name, &sp);
+    if S_ISDIR(sp.st_mode) return true;
+    if (S_ISLNK(sp.st_mode) || not S_ISREG(sp.st_mode)) {
       fstatat(dirfd(dp), ep->d_name, &sp, 0);
       return S_ISDIR(sp.st_mode);
     }

--- a/nall/directory.hpp
+++ b/nall/directory.hpp
@@ -267,6 +267,15 @@ inline auto directory::copy(const string& source, const string& target) -> bool 
   }
 #else
   inline auto directoryIsFolder(DIR* dp, struct dirent* ep) -> bool {
+#if defined(PLATFORM_HAIKU)
+    struct stat sp = {0};
+    stat(ep->d_name, &sp);
+    if S_ISDIR(sp.st_mode) return true;
+    if (S_ISLNK(sp.st_mode) || not S_ISREG(sp.st_mode)) {
+      fstatat(dirfd(dp), ep->d_name, &sp, 0);
+      return S_ISDIR(sp.st_mode);
+    }
+#else // not PLATFORM_HAIKU
     if(ep->d_type == DT_DIR) return true;
     if(ep->d_type == DT_LNK || ep->d_type == DT_UNKNOWN) {
       //symbolic links must be resolved to determine type
@@ -274,6 +283,7 @@ inline auto directory::copy(const string& source, const string& target) -> bool 
       fstatat(dirfd(dp), ep->d_name, &sp, 0);
       return S_ISDIR(sp.st_mode);
     }
+#endif
     return false;
   }
 

--- a/nall/intrinsics.hpp
+++ b/nall/intrinsics.hpp
@@ -4,7 +4,7 @@ namespace nall {
   using uint = unsigned;
 
   enum class Compiler : uint { Clang, GCC, Microsoft, Unknown };
-  enum class Platform : uint { Windows, MacOS, Linux, BSD, Android, Unknown };
+  enum class Platform : uint { Windows, MacOS, Linux, BSD, Haiku, Android, Unknown };
   enum class API : uint { Windows, Posix, Unknown };
   enum class DisplayServer : uint { Windows, Quartz, Xorg, Unknown };
   enum class Architecture : uint { x86, amd64, ARM32, ARM64, PPC32, PPC64, Unknown };
@@ -105,6 +105,13 @@ namespace nall {
   constexpr auto platform() -> Platform { return Platform::BSD; }
   constexpr auto api() -> API { return API::Posix; }
   constexpr auto display() -> DisplayServer { return DisplayServer::Xorg; }
+#elif defined(__HAIKU__)
+  #define PLATFORM_HAIKU
+  #define API_POSIX
+  #define DISPLAY_UNKNOWN
+  constexpr auto platform() -> Platform { return Platform::Haiku; }
+  constexpr auto api() -> API { return API::Posix; }
+  constexpr auto display() -> DisplayServer { return DisplayServer::Unknown; }
 #else
   #warning "unable to detect platform"
   #define PLATFORM_UNKNOWN

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -35,11 +35,6 @@ ifeq ($(ruby),)
     $(eval $(call pkg_check,libpulse,audio.pulseaudiosimple))
     ruby += input.xlib
     $(eval $(call pkg_check,sdl2,input.sdl))
-  else ifeq ($(platform),haiku)
-    ruby += video.glx video.glx2
-    ruby += audio.oss
-    $(eval $(call pkg_check,openal,audio.openal))
-    $(eval $(call pkg_check,sdl2,input.sdl))
   endif
 endif
 

--- a/ruby/GNUmakefile
+++ b/ruby/GNUmakefile
@@ -35,6 +35,11 @@ ifeq ($(ruby),)
     $(eval $(call pkg_check,libpulse,audio.pulseaudiosimple))
     ruby += input.xlib
     $(eval $(call pkg_check,sdl2,input.sdl))
+  else ifeq ($(platform),haiku)
+    ruby += video.glx video.glx2
+    ruby += audio.oss
+    $(eval $(call pkg_check,openal,audio.openal))
+    $(eval $(call pkg_check,sdl2,input.sdl))
   endif
 endif
 


### PR DESCRIPTION
For your consideration, this allows building the libretro target on the Haiku operating system. Haiku is mostly POSIX but doesn't have a full port of GTK hence standalone bsnes is a no-go, but the libretro target builds and works flawlessly.