### PR TITLE
Add mode presets for accuracy and performance mode to simplify enhancements settings [v2]

### DIFF
--- a/bsnes/target-bsnes/settings/enhancements.cpp
+++ b/bsnes/target-bsnes/settings/enhancements.cpp
@@ -25,7 +25,7 @@ auto EnhancementSettings::create() -> void {
   if(settings.emulator.runAhead.frames == 4) runAhead4.setChecked();
   runAheadSpacer.setColor({192, 192, 192});
 
-  overclockingLabel.setText("Overclocking").setFont(Font().setBold());
+  overclockingLabel.setText("Overclocking (this will break games, cause bugs and reduce performance!)").setFont(Font().setBold());
   overclockingLayout.setSize({3, 3});
   overclockingLayout.column(0).setAlignment(1.0);
   overclockingLayout.column(1).setAlignment(0.5);
@@ -124,7 +124,6 @@ auto EnhancementSettings::create() -> void {
   ).onToggle([&] {
     settings.emulator.hack.coprocessor.preferHLE = coprocessorPreferHLEOption.checked();
   });
-  coprocessorSpacer.setColor({192, 192, 192});
 
   gameLabel.setText("Game Enhancements").setFont(Font().setBold());
   hotfixes.setText("Hotfixes").setToolTip({
@@ -133,6 +132,54 @@ auto EnhancementSettings::create() -> void {
   }).setChecked(settings.emulator.hack.hotfixes).onToggle([&] {
     settings.emulator.hack.hotfixes = hotfixes.checked();
   });
+  hotfixesSpacer.setColor({192, 192, 192});
 
-  note.setText("Note: some settings do not take effect until after reloading games.");
+  ppuModeLabel.setText("Mode Presets:").setFont(Font().setBold());
+  ppuModeRequirements.setText(
+    "Accuracy Mode: Maximum hardware accuracy, but PPUs timings aren't 100% correct yet.\n"
+    "Compatibility Mode: Most compatible way to play games paired with good performance. [Recommended]"
+  );
+  accuracyMode.setText("Accuracy Mode").onActivate([&] {
+    runAhead0.setChecked(); settings.emulator.runAhead.frames = 0;
+    cpuClock.setPosition(0).doChange();
+    sa1Clock.setPosition(0).doChange();
+    sfxClock.setPosition(0).doChange();
+    fastPPU.setChecked(false).doToggle();
+    fastDSP.setChecked(false).doToggle();
+    cubicInterpolation.setChecked(false).doToggle();
+    coprocessorDelayedSyncOption.setChecked(false).doToggle();
+    coprocessorPreferHLEOption.setChecked(false).doToggle();
+    hotfixes.setChecked(false).doToggle();
+
+    if(!emulator->loaded()) return;
+    MessageDialog().setAlignment(settingsWindow).setTitle("Success").setText({
+      "Accuracy Mode applied.\n"
+      "Reload the game in order for all changes to take effect."
+    }).information();
+  });
+
+  compatibilityMode.setText("Compatibility Mode").onActivate([&] {
+    runAhead0.setChecked(); settings.emulator.runAhead.frames = 0;
+    cpuClock.setPosition(0).doChange();
+    sa1Clock.setPosition(0).doChange();
+    sfxClock.setPosition(0).doChange();
+    fastPPU.setChecked(true).doToggle();
+    deinterlace.setChecked(true).doToggle();
+    noSpriteLimit.setChecked(false).doToggle();
+    mode7Scale.item(0).setSelected(); emulator->configure("Hacks/PPU/Mode7/Scale", settings.emulator.hack.ppu.mode7.scale = 1);
+    mode7Perspective.setChecked(true).doToggle();
+    mode7Supersample.setChecked(false).doToggle();
+    mode7Mosaic.setChecked(true).doToggle();
+    fastDSP.setChecked(false).doToggle();
+    cubicInterpolation.setChecked(false).doToggle();
+    coprocessorDelayedSyncOption.setChecked(false).doToggle();
+    coprocessorPreferHLEOption.setChecked(false).doToggle();
+    hotfixes.setChecked(true).doToggle();
+
+    if(!emulator->loaded()) return;
+    MessageDialog().setAlignment(settingsWindow).setTitle("Success").setText({
+      "Compatibility Mode applied.\n"
+      "Reload the game in order for all changes to take effect."
+    }).information();
+  });
 }

--- a/bsnes/target-bsnes/settings/settings.hpp
+++ b/bsnes/target-bsnes/settings/settings.hpp
@@ -382,13 +382,16 @@ public:
   HorizontalLayout coprocessorLayout{this, Size{~0, 0}};
     CheckLabel coprocessorDelayedSyncOption{&coprocessorLayout, Size{0, 0}};
     CheckLabel coprocessorPreferHLEOption{&coprocessorLayout, Size{0, 0}};
-  Canvas coprocessorSpacer{this, Size{~0, 1}};
   //
   Label gameLabel{this, Size{~0, 0}, 2};
-  CheckLabel hotfixes{this, Size{0, 0}};
+    CheckLabel hotfixes{this, Size{0, 0}};
+  Canvas hotfixesSpacer{this, Size{~0, 1}};
   //
-  Widget spacer{this, Size{~0, ~0}};
-  Label note{this, Size{~0, 0}};
+  Label ppuModeLabel{this, Size{~0, 0}, 0};
+  Label ppuModeRequirements{this, Size{~0, 0}};
+  HorizontalLayout modeLayout{this, Size{~0, 0}};
+    Button accuracyMode{&modeLayout, Size{0, 0}};
+    Button compatibilityMode{&modeLayout, Size{0, 0}};
 };
 
 struct CompatibilitySettings : VerticalLayout {


### PR DESCRIPTION

https://user-images.githubusercontent.com/79463574/134745811-06480477-1d72-4392-9711-734a7915254e.mp4

V2. I did some changes because of this comment: https://github.com/bsnes-emu/bsnes/pull/158#issuecomment-894676863

> When a game is loaded, you will get an information that you should reload the game in order for all changes to take effect. If no game is loaded, you will not see this, because the changes will take effect immediately. It's working really good and I think with that user will better unterstand what they have to enable for a good gaming experience.
> 
> Other than that, I'm not sure whats the best way to describe these two mode presets, but I don't think something like:
> Performance mode: Maximum speed, [...]
> is right, because it isn't just about speed, that's why something like "Prefer HLE" is disabled. We should come up with something appropriate, so people want to use this mode by default. You can decide what's the best way to do this.
> 
> Thanks again for your help, Screwtape. :)

Fixes: #113