### PR TITLE
Added fast PPU override for Bishoujo Janshi Suchie-Pai and Dragon Knight 4 (fixes character sprites/text rendering)

### DIFF
--- a/bsnes/target-bsnes/program/hacks.cpp
+++ b/bsnes/target-bsnes/program/hacks.cpp
@@ -15,6 +15,12 @@ auto Program::hackCompatibility() -> void {
   //the dialogue text is blurry due to an issue in the scanline-based renderer's color math support
   if(title == "マーヴェラス") fastPPU = false;
 
+  //the character sprites are incorrect due to an issue in the scanline-based renderer's color math support
+  if(title == "SUUCHIIPAI") fastPPU = false;
+  
+  //the pause menu text is blurry due to an issue in the scanline-based renderer's color math support
+  if(title == "DRAGON KNIGHT 4") fastPPU = false;
+  
   //stage 2 uses pseudo-hires in a way that's not compatible with the scanline-based renderer
   if(title == "SFC クレヨンシンチャン") fastPPU = false;
 


### PR DESCRIPTION

Bishoujo Janshi Suchie-Pai (Japan)

![Bishoujo Janshi Suchie-Pai (Japan)](https://user-images.githubusercontent.com/57050261/134807625-e41cdb5c-ba01-4018-94c5-39fbc80390b4.jpg)

Dragon Knight 4

![Dragon_Knight_4](https://user-images.githubusercontent.com/57050261/134807653-b6088e63-e9b3-4cb0-a720-806e0a6a5387.png)

![Dragon_Knight_4_2](https://user-images.githubusercontent.com/57050261/134807604-5c9de8af-a786-4238-bb72-21b90ac3de8a.png)

