### PR TITLE
build: Remove root check for make install.

### DIFF
--- a/bsnes/target-bsnes/GNUmakefile
+++ b/bsnes/target-bsnes/GNUmakefile
@@ -40,8 +40,6 @@ verbose: hiro.verbose ruby.verbose nall.verbose all;
 
 install: all
 ifeq ($(platform),windows)
-else ifeq ($(shell id -un),root)
-	$(error "make install should not be run as root")
 else ifeq ($(platform),macos)
 	mkdir -p ~/Library/Application\ Support/$(name)/
 	mkdir -p ~/Library/Application\ Support/$(name)/Database/
@@ -67,8 +65,6 @@ endif
 
 uninstall:
 ifeq ($(platform),windows)
-else ifeq ($(shell id -un),root)
-	$(error "make uninstall should not be run as root")
 else ifeq ($(platform),macos)
 	rm -rf /Applications/$(name).app
 else ifneq ($(filter $(platform),linux bsd),)


### PR DESCRIPTION
The first patch from PR https://github.com/bsnes-emu/bsnes/pull/131.

Removes the check disabling the `install` and `uninstall` checks when run as root. Some distros like Slackware build and create packages as root and there are tools like sandbox (https://wiki.gentoo.org/wiki/Project:Sandbox) designed to catch programs that install out of the expected paths.

@Screwtapello Perhaps it will get the ball rolling focusing on one patch at a time?