### PR TITLE
nall: Fix the build for gcc13

### DIFF
--- a/nall/arithmetic/natural.hpp
+++ b/nall/arithmetic/natural.hpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #define ConcatenateType(Size) uint##Size##_t
 #define DeclareType(Size) ConcatenateType(Size)
 


### PR DESCRIPTION
```
Compiling hiro/hiro.cpp ...
In file included from ../nall/arithmetic.hpp:37,
                 from ../nall/hash/hash.hpp:3,
                 from ../nall/hash/sha256.hpp:3,
                 from ../nall/file-buffer.hpp:12,
                 from ../nall/file.hpp:3,
                 from ../nall/directory.hpp:3,
                 from ../hiro/core/core.hpp:4,
                 from ../hiro/core/core.cpp:13,
                 from ../hiro/hiro.cpp:5:
../nall/arithmetic/natural.hpp: In function 'void nall::div(const uint256_t&, const uint256_t&, uint256_t&, uint256_t&)':
../nall/arithmetic/natural.hpp:239:23: error: 'runtime_error' is not a member of 'std'
  239 |   if(!rhs) throw std::runtime_error("division by zero");
      |                       ^~~~~~~~~~~~~
../nall/arithmetic/natural.hpp:1:1: note: 'std::runtime_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?
  +++ |+#include <stdexcept>
    1 | #define ConcatenateType(Size) uint##Size##_t
In file included from ../nall/arithmetic.hpp:45:
../nall/arithmetic/natural.hpp: In function 'void nall::div(const uint512_t&, const uint512_t&, uint512_t&, uint512_t&)':
../nall/arithmetic/natural.hpp:239:23: error: 'runtime_error' is not a member of 'std'
  239 |   if(!rhs) throw std::runtime_error("division by zero");
      |                       ^~~~~~~~~~~~~
../nall/arithmetic/natural.hpp:239:23: note: 'std::runtime_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?
In file included from ../nall/arithmetic.hpp:53:
../nall/arithmetic/natural.hpp: In function 'void nall::div(const uint1024_t&, const uint1024_t&, uint1024_t&, uint1024_t&)':
../nall/arithmetic/natural.hpp:239:23: error: 'runtime_error' is not a member of 'std'
  239 |   if(!rhs) throw std::runtime_error("division by zero");
      |                       ^~~~~~~~~~~~~
../nall/arithmetic/natural.hpp:239:23: note: 'std::runtime_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?
In file included from ../nall/arithmetic.hpp:61:
../nall/arithmetic/natural.hpp: In function 'void nall::div(const uint2048_t&, const uint2048_t&, uint2048_t&, uint2048_t&)':
../nall/arithmetic/natural.hpp:239:23: error: 'runtime_error' is not a member of 'std'
  239 |   if(!rhs) throw std::runtime_error("division by zero");
      |                       ^~~~~~~~~~~~~
../nall/arithmetic/natural.hpp:239:23: note: 'std::runtime_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?
In file included from ../nall/arithmetic.hpp:69:
../nall/arithmetic/natural.hpp: In function 'void nall::div(const uint4096_t&, const uint4096_t&, uint4096_t&, uint4096_t&)':
../nall/arithmetic/natural.hpp:239:23: error: 'runtime_error' is not a member of 'std'
  239 |   if(!rhs) throw std::runtime_error("division by zero");
      |                       ^~~~~~~~~~~~~
../nall/arithmetic/natural.hpp:239:23: note: 'std::runtime_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?
In file included from ../nall/arithmetic.hpp:77:
../nall/arithmetic/natural.hpp: In function 'void nall::div(const uint8192_t&, const uint8192_t&, uint8192_t&, uint8192_t&)':
../nall/arithmetic/natural.hpp:239:23: error: 'runtime_error' is not a member of 'std'
  239 |   if(!rhs) throw std::runtime_error("division by zero");
      |                       ^~~~~~~~~~~~~
../nall/arithmetic/natural.hpp:239:23: note: 'std::runtime_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?
make: *** [../hiro/GNUmakefile:85: obj/hiro-gtk2.o] Error 1
```