### PR TITLE
nall: Add needed #include <stdexcept>

### DIFF
--- a/nall/arithmetic.hpp
+++ b/nall/arithmetic.hpp
@@ -3,6 +3,8 @@
 //multi-precision arithmetic
 //warning: each size is quadratically more expensive than the size before it!
 
+#include <stdexcept>
+
 #include <nall/stdint.hpp>
 #include <nall/string.hpp>
 #include <nall/range.hpp>


### PR DESCRIPTION
Taken from ares commit 6a7898396a14eef257e63cd002fb26ffbf6e2581

Apparently this is needed by GCC 13.