### PR TITLE
Revert "nall: Add needed #include <stdexcept>"

### DIFF
--- a/nall/arithmetic.hpp
+++ b/nall/arithmetic.hpp
@@ -3,8 +3,6 @@
 //multi-precision arithmetic
 //warning: each size is quadratically more expensive than the size before it!
 
-#include <stdexcept>
-
 #include <nall/stdint.hpp>
 #include <nall/string.hpp>
 #include <nall/range.hpp>


### PR DESCRIPTION
This reverts commit e658f50da2f0b142f672452abad987341e81efd4.

bsnes' compatibility with GCC 13 was already fixed in a different way in 5cefce5c08f74cfc80eee3f82a32d846144e5277.