### PR TITLE
libretro: Support blargg's NTSC filter

### DIFF
--- a/bsnes/target-libretro/program.cpp
+++ b/bsnes/target-libretro/program.cpp
@@ -46,6 +46,7 @@ struct Program : Emulator::Platform
 	auto openRomBSMemory(string name, vfs::file::mode mode) -> shared_pointer<vfs::file>;
 	
 	auto hackPatchMemory(vector<uint8_t>& data) -> void;
+	auto updateVideoPalette() -> void;
 	
 	string base_name;
 
@@ -79,6 +80,13 @@ public:
 	struct BSMemory : Game {
 		vector<uint8_t> program;
 	} bsMemory;
+
+	uint32_t palette[32768];
+	uint32_t paletteDimmed[32768];
+	uint32_t videoOut[2304*2160];
+
+	Filter::Render filterRender;
+	Filter::Size filterSize;
 };
 
 static Program *program = nullptr;
@@ -157,6 +165,59 @@ auto Program::open(uint id, string name, vfs::file::mode mode, bool required) ->
 	return result;
 }
 
+auto Program::updateVideoPalette() -> void {
+  double luminance = 100.0 / 100.0;
+  double saturation = 100.0 / 100.0;
+  double gamma = 150.0 / 100.0;
+
+  uint depth = 24;
+
+  for(uint color : range(32768)) {
+    uint16 r = (color >> 10) & 31;
+    uint16 g = (color >>  5) & 31;
+    uint16 b = (color >>  0) & 31;
+
+    r = r << 3 | r >> 2; r = r << 8 | r << 0;
+    g = g << 3 | g >> 2; g = g << 8 | g << 0;
+    b = b << 3 | b >> 2; b = b << 8 | b << 0;
+
+    if(saturation != 1.0) {
+      uint16 grayscale = uclamp<16>((r + g + b) / 3);
+      double inverse = max(0.0, 1.0 - saturation);
+      r = uclamp<16>(r * saturation + grayscale * inverse);
+      g = uclamp<16>(g * saturation + grayscale * inverse);
+      b = uclamp<16>(b * saturation + grayscale * inverse);
+    }
+
+    if(gamma != 1.0) {
+      double reciprocal = 1.0 / 32767.0;
+      r = r > 32767 ? r : uint16(32767 * pow(r * reciprocal, gamma));
+      g = g > 32767 ? g : uint16(32767 * pow(g * reciprocal, gamma));
+      b = b > 32767 ? b : uint16(32767 * pow(b * reciprocal, gamma));
+    }
+
+    if(luminance != 1.0) {
+      r = uclamp<16>(r * luminance);
+      g = uclamp<16>(g * luminance);
+      b = uclamp<16>(b * luminance);
+    }
+
+    switch(depth) {
+    case 24: palette[color] = r >> 8 << 16 | g >> 8 <<  8 | b >> 8 << 0; break;
+    case 30: palette[color] = r >> 6 << 20 | g >> 6 << 10 | b >> 6 << 0; break;
+    }
+
+    r >>= 1;
+    g >>= 1;
+    b >>= 1;
+
+    switch(depth) {
+    case 24: paletteDimmed[color] = r >> 8 << 16 | g >> 8 <<  8 | b >> 8 << 0; break;
+    case 30: paletteDimmed[color] = r >> 6 << 20 | g >> 6 << 10 | b >> 6 << 0; break;
+    }
+  }
+}
+
 auto Program::load() -> void {
 	emulator->unload();
 	emulator->load();
@@ -227,12 +288,12 @@ auto Program::load(uint id, string name, string type, vector<string> options) ->
 	{
 		if (loadGameBoy(gameBoy.location))
 		{
-			return { id, NULL };
+			return { id, "" };
 		}
 	}
 	else if (id == 3) {
 		if (loadBSMemory(bsMemory.location)) {
-			return { id, NULL };
+			return { id, "" };
 		}
 	}
 	return { id, options(0) };
@@ -245,7 +306,20 @@ auto Program::videoFrame(const uint16* data, uint pitch, uint width, uint height
 		data += 8 * (pitch >> 1) * multiplier;
 		height -= 16 * multiplier;
 	}
-	video_cb(data, width, height, pitch);
+
+	uint filterWidth = width, filterHeight = height;
+
+	filterSize(filterWidth, filterHeight);
+
+	// Scale the NTSC filter properly for HD Mode 7
+	if ((scale > 1) && (filterWidth == 602))
+	{
+		filterWidth = 301 * scale;
+	}
+
+	filterRender(palette, videoOut, filterWidth << 2, (const uint16_t*)data, pitch, width, height);
+
+	video_cb(videoOut, filterWidth, filterHeight, filterWidth << 2);
 }
 
 // Double the fun!


### PR DESCRIPTION
This adds support for all four of blargg's NTSC filter options to the libretro port of bsnes.

As a consequence of using the filter functionality, the pixel format has been changed to XRGB8888 (preferable to the awkward 0RGB1555 when considering cross-platform compatibility and it is seemingly deprecated anyway). It also now builds on musl-libc without patches.

Closes #289