### PR TITLE
wdc65816: fix PLB wrapping in emulation mode

### DIFF
--- a/bsnes/processor/wdc65816/instructions-other.cpp
+++ b/bsnes/processor/wdc65816/instructions-other.cpp
@@ -205,9 +205,10 @@ E S.h = 0x01;
 auto WDC65816::instructionPullB() -> void {
   idle();
   idle();
-L B = pull();
+L B = pullN();
   ZF = B == 0;
   NF = B & 0x80;
+E S.h = 0x01;
 }
 
 auto WDC65816::instructionPullP() -> void {


### PR DESCRIPTION
Cherry-picked https://github.com/ares-emulator/ares/commit/e589f8d9cf1aaf04b1959bfc7d7085cb3861149c.
I've checked and confirmed this does fix the test in question.
Note that this does not fix the additional tests from [version 1.2](https://github.com/gilyon/snes-tests/releases/tag/v1.2) of the cpu test rom.