### PR TITLE
Implementation of SA-1 BW-RAM protection

### DIFF
--- a/bsnes/sfc/coprocessor/sa1/io.cpp
+++ b/bsnes/sfc/coprocessor/sa1/io.cpp
@@ -108,8 +108,16 @@ auto SA1::writeIOCPU(uint address, uint8 data) -> void {
   //(CCNT) SA-1 control
   case 0x2200: {
     if(mmio.sa1_resb && !(data & 0x20)) {
-      //reset SA-1 CPU (PC bank set to 0x00)
+      //reset SA-1 CPU (PC bank and data bank set to 0x00, clear STP status)
       r.pc.d = mmio.crv;
+      r.b    = 0x00;
+      r.stp  = false;
+      //todo: probably needs a SA-1 CPU reset
+      //reset r.s, r.e, r.wai ...
+
+      //reset io status
+      //todo: reset timing is unknown, CIWP is set to 0 at reset
+      mmio.ciwp = 0x00;
     }
 
     mmio.sa1_irq  = (data & 0x80);

--- a/bsnes/sfc/coprocessor/sa1/memory.cpp
+++ b/bsnes/sfc/coprocessor/sa1/memory.cpp
@@ -37,7 +37,7 @@ auto SA1::read(uint address) -> uint8 {
   }
 
   if((address & 0x40e000) == 0x006000  //00-3f,80-bf:6000-7fff
-  || (address & 0xf00000) == 0x400000  //40-4f:0000-ffff
+  || (address & 0xe00000) == 0x400000  //40-5f:0000-ffff
   || (address & 0xf00000) == 0x600000  //60-6f:0000-ffff
   ) {
     step();
@@ -81,7 +81,7 @@ auto SA1::write(uint address, uint8 data) -> void {
   }
 
   if((address & 0x40e000) == 0x006000  //00-3f,80-bf:6000-7fff
-  || (address & 0xf00000) == 0x400000  //40-4f:0000-ffff
+  || (address & 0xe00000) == 0x400000  //40-5f:0000-ffff
   || (address & 0xf00000) == 0x600000  //60-6f:0000-ffff
   ) {
     step();


### PR DESCRIPTION
Manually cherry-picked ares commit https://github.com/ares-emulator/ares/commit/70f361094b2983bc783957083be9d7d46cf39bf2.

Testing with the test rom from https://github.com/absindx/SNES-TestRoms/tree/267b128a84afdd250a51967963fa7fba4184399e/SA1RamProtectionTest, the following previously failing tests now pass:

2, 6, 39-66, 93-118, 155, 157-166, 168, 172, 179-190, 192, 194, 195, 198, 199, 203, 204, 208, 209, 211, 213, 215, 216* (test 216 freezes and doesn't allow progressing to further tests).