### PR TITLE
Fix a crash in heuristic memory mapping.

### DIFF
--- a/bsnes/heuristics/super-famicom.cpp
+++ b/bsnes/heuristics/super-famicom.cpp
@@ -271,7 +271,7 @@ auto SuperFamicom::board() const -> string {
   //Bishoujo Senshi Sailor Moon SuperS - Fuwafuwa Panic (Japan)
   //so we identify it with this embedded string
   string sufamiSignature = "BANDAI SFC-ADX";
-  if (string(data.view(0, sufamiSignature.length())) == sufamiSignature) board.append("ST-", mode);
+  if (string_view(data.data(), sufamiSignature.length()) == sufamiSignature) board.append("ST-", mode);
 
   //this game's title ovewrites the map mode with '!' (0x21), but is a LOROM game
   if(title() == "YUYU NO QUIZ DE GO!GO") mode = "LOROM-";


### PR DESCRIPTION
Commit 712ed9b6b0d7aa00919738335d586c21fa9221c6 changed the way that the Sufami Turbo base cartridge was detected, but it caused crashes. Apparently the way we were converting the binary ROM data to a string for comparison, was actually calling the wrong `string` constructor. Let's more explicitly create a string_view instead of hoping for the compiler to pick a suitable constructor chain.