### PR TITLE
Implement SA1 I-RAM write protection

### DIFF
--- a/bsnes/sfc/coprocessor/sa1/iram.cpp
+++ b/bsnes/sfc/coprocessor/sa1/iram.cpp
@@ -24,6 +24,7 @@ auto SA1::IRAM::readCPU(uint address, uint8 data) -> uint8 {
 
 auto SA1::IRAM::writeCPU(uint address, uint8 data) -> void {
   cpu.synchronizeCoprocessors();
+  if(!(sa1.mmio.siwp & 1 << (address >> 8 & 7))) return;
   return write(address, data);
 }
 
@@ -32,5 +33,6 @@ auto SA1::IRAM::readSA1(uint address, uint8 data) -> uint8 {
 }
 
 auto SA1::IRAM::writeSA1(uint address, uint8 data) -> void {
+  if(!(sa1.mmio.ciwp & 1 << (address >> 8 & 7))) return;
   return write(address, data);
 }


### PR DESCRIPTION
Logic is based on [what ares does](https://github.com/ares-emulator/ares/blob/d6858ad8219a031a02dd4c91f90f69be6349b1ee/ares/sfc/coprocessor/sa1/iram.cpp).

I've checked with the testrom from https://github.com/absindx/SNES-TestRoms/tree/a229ee7215effdd1d21ef70dbcb15694ac4d8046/SA1RamProtectionTest and have confirmed that bsnes now passes all tests.