### PR TITLE
Improve auto-joypad polling timing

### DIFF
--- a/bsnes/emulator/emulator.hpp
+++ b/bsnes/emulator/emulator.hpp
@@ -35,7 +35,7 @@ namespace Emulator {
   static const string Website   = "https://bsnes.dev";
 
   //incremented only when serialization format changes
-  static const string SerializerVersion = "115";
+  static const string SerializerVersion = "115.1";
 
   namespace Constants {
     namespace Colorburst {

--- a/bsnes/sfc/cpu/cpu.hpp
+++ b/bsnes/sfc/cpu/cpu.hpp
@@ -120,8 +120,8 @@ private:
 
     uint autoJoypadCounter = 33;  //state machine; 4224 / 128 = 33 (inactive)
 
-    uint2 autoJoypadPort0 = 0;
     uint2 autoJoypadPort1 = 0;
+    uint2 autoJoypadPort2 = 0;
 
     bool cpuLatch = false;
     bool autoJoypadLatch = false;

--- a/bsnes/sfc/cpu/cpu.hpp
+++ b/bsnes/sfc/cpu/cpu.hpp
@@ -122,6 +122,9 @@ private:
 
     uint2 autoJoypadPort0 = 0;
     uint2 autoJoypadPort1 = 0;
+
+    bool cpuLatch = false;
+    bool autoJoypadLatch = false;
   } status;
 
   struct IO {

--- a/bsnes/sfc/cpu/cpu.hpp
+++ b/bsnes/sfc/cpu/cpu.hpp
@@ -119,6 +119,9 @@ private:
     bool hdmaMode = 0;  //0 = init, 1 = run
 
     uint autoJoypadCounter = 33;  //state machine; 4224 / 128 = 33 (inactive)
+
+    uint2 autoJoypadPort0 = 0;
+    uint2 autoJoypadPort1 = 0;
   } status;
 
   struct IO {

--- a/bsnes/sfc/cpu/io.cpp
+++ b/bsnes/sfc/cpu/io.cpp
@@ -136,7 +136,14 @@ auto CPU::writeCPU(uint addr, uint8 data) -> void {
 
   case 0x4200:  //NMITIMEN
     io.autoJoypadPoll = data & 1;
-    if(!io.autoJoypadPoll) status.autoJoypadCounter = 33; // Disable auto-joypad read
+    if(status.autoJoypadCounter < 2) {
+      // allow controller latches during this time
+      controllerPort1.device->latch(io.autoJoypadPoll);
+      controllerPort2.device->latch(io.autoJoypadPoll);
+    }else if (!io.autoJoypadPoll) {
+      status.autoJoypadCounter = 33; // Disable auto-joypad read
+    }
+
     nmitimenUpdate(data);
     return;
 

--- a/bsnes/sfc/cpu/io.cpp
+++ b/bsnes/sfc/cpu/io.cpp
@@ -130,18 +130,20 @@ auto CPU::writeCPU(uint addr, uint8 data) -> void {
     //bit 0 is shared between JOYSER0 and JOYSER1:
     //strobing $4016.d0 affects both controller port latches.
     //$4017 bit 0 writes are ignored.
-    controllerPort1.device->latch(data & 1);
-    controllerPort2.device->latch(data & 1);
+    status.cpuLatch = data & 1;
+    controllerPort1.device->latch(status.autoJoypadLatch | status.cpuLatch);
+    controllerPort2.device->latch(status.autoJoypadLatch | status.cpuLatch);
     return;
 
   case 0x4200:  //NMITIMEN
     io.autoJoypadPoll = data & 1;
-    if(status.autoJoypadCounter < 2) {
+    if(status.autoJoypadCounter == 0) {
       // allow controller latches during this time
-      controllerPort1.device->latch(io.autoJoypadPoll);
-      controllerPort2.device->latch(io.autoJoypadPoll);
-    }else if (!io.autoJoypadPoll) {
-      status.autoJoypadCounter = 33; // Disable auto-joypad read
+      status.autoJoypadLatch = io.autoJoypadPoll;
+      controllerPort1.device->latch(status.autoJoypadLatch | status.cpuLatch);
+      controllerPort2.device->latch(status.autoJoypadLatch | status.cpuLatch);
+    } else if (!io.autoJoypadPoll && status.autoJoypadCounter >= 2) {
+      status.autoJoypadCounter = 33;
     }
 
     nmitimenUpdate(data);

--- a/bsnes/sfc/cpu/serialization.cpp
+++ b/bsnes/sfc/cpu/serialization.cpp
@@ -45,6 +45,9 @@ auto CPU::serialize(serializer& s) -> void {
 
   s.integer(status.autoJoypadCounter);
 
+  s.integer(status.autoJoypadPort0);
+  s.integer(status.autoJoypadPort1);
+
   s.integer(io.wramAddress);
 
   s.boolean(io.hirqEnable);

--- a/bsnes/sfc/cpu/serialization.cpp
+++ b/bsnes/sfc/cpu/serialization.cpp
@@ -45,8 +45,8 @@ auto CPU::serialize(serializer& s) -> void {
 
   s.integer(status.autoJoypadCounter);
 
-  s.integer(status.autoJoypadPort0);
   s.integer(status.autoJoypadPort1);
+  s.integer(status.autoJoypadPort2);
 
   s.boolean(status.cpuLatch);
   s.boolean(status.autoJoypadLatch);

--- a/bsnes/sfc/cpu/serialization.cpp
+++ b/bsnes/sfc/cpu/serialization.cpp
@@ -48,6 +48,9 @@ auto CPU::serialize(serializer& s) -> void {
   s.integer(status.autoJoypadPort0);
   s.integer(status.autoJoypadPort1);
 
+  s.boolean(status.cpuLatch);
+  s.boolean(status.autoJoypadLatch);
+
   s.integer(io.wramAddress);
 
   s.boolean(io.hirqEnable);

--- a/bsnes/sfc/cpu/timing.cpp
+++ b/bsnes/sfc/cpu/timing.cpp
@@ -243,13 +243,13 @@ auto CPU::joypadEdge() -> void {
     //sixteen bits are shifted into joy{1-4}, one bit per 256 clocks
     //the bits are read on one 128-clock cycle and written on the next
     if ((status.autoJoypadCounter & 1) == 0) {
-      status.autoJoypadPort0 = controllerPort1.device->data();
-      status.autoJoypadPort1 = controllerPort2.device->data();
+      status.autoJoypadPort1 = controllerPort1.device->data();
+      status.autoJoypadPort2 = controllerPort2.device->data();
     } else {
-      io.joy1 = io.joy1 << 1 | status.autoJoypadPort0.bit(0);
-      io.joy2 = io.joy2 << 1 | status.autoJoypadPort1.bit(0);
-      io.joy3 = io.joy3 << 1 | status.autoJoypadPort0.bit(1);
-      io.joy4 = io.joy4 << 1 | status.autoJoypadPort1.bit(1);
+      io.joy1 = io.joy1 << 1 | status.autoJoypadPort1.bit(0);
+      io.joy2 = io.joy2 << 1 | status.autoJoypadPort2.bit(0);
+      io.joy3 = io.joy3 << 1 | status.autoJoypadPort1.bit(1);
+      io.joy4 = io.joy4 << 1 | status.autoJoypadPort2.bit(1);
     }
   }
 }

--- a/bsnes/sfc/cpu/timing.cpp
+++ b/bsnes/sfc/cpu/timing.cpp
@@ -238,7 +238,7 @@ auto CPU::joypadEdge() -> void {
     return;
   }
 
-  if(status.autoJoypadCounter >= 2 && !(status.autoJoypadCounter & 1)) {
+  if(status.autoJoypadCounter >= 2 && (status.autoJoypadCounter & 1)) {
     //sixteen bits are shifted into joy{1-4}, one bit per 256 clocks
     uint2 port0 = controllerPort1.device->data();
     uint2 port1 = controllerPort2.device->data();


### PR DESCRIPTION
This fixes #322.

In addition, these changes improve results in a number of test roms from https://github.com/bsnes-emu/bsnes/issues/322#issuecomment-2952297191.

Most of these test roms aren't "good or bad" and instead show trends and general behavior. In some cases it's clear when the emulator behavior is wrong and in other cases it's not so clear. The displayed values are not fixed and change frame-by-frame. I think it is most important to *roughly* match the hardware result. In some cases there may not even be one true correct result as even different hardware differs in results.

That being said, on current master the following tests are **clearly bad**:
```
01 auto-joy-timing-test
05 blip-autojoy-test-automatic
06 enable-autojoy-late-test-2
07 blip-autojoy-test
08 joypad-latch-set-during-autojoy
09 joypad-latch-clear-during-autojoy
10 joyser0-read-during-autojoy
12 blip-autojoy-timing-test
13 blip-autojoy-latches-joypad-test
14 clear-autojoy-after-autojoy-active
```

With the changes in this PR, all of these tests seem "fixed", at least mostly.

Notable remaining differences with hardware:
- Test 04 now has more `FFFF` in the column on the right. Should be 3-6 from the top, is 4-8.
- The right-most column in test 06 is a solid block of `FFFF` and does not flicker with occasional `0000` (it does on hardware).
- When holding `B` in test 08, the fourth row under `JOY 1` will never show `FFFF`, it shows `BFFF` at most.
- Similar to above, in test 09 when holding `B` the third row under `JOY 1` can never show `C000`, only `E000` and `F000`.
- When holding a key like `Y` in test 10, the left-most column under `JOY 1` may show 0s, but the video from hardware only shows 4s and 8s.

These are mainly minor off-by-1 problems, and roughly half of these also show in Mesen. I think the current results are good enough for now.