### PR TITLE
fix bg mode 4 in accurate ppu

### DIFF
--- a/bsnes/sfc/ppu/background.cpp
+++ b/bsnes/sfc/ppu/background.cpp
@@ -61,7 +61,7 @@ auto PPU::Background::fetchNameTable() -> void {
         if(!(hlookup & 0x8000)) {
           hoffset = hpixel + (hlookup & ~7) + (hscroll & 7);
         } else {
-          voffset = vpixel + (vlookup);
+          voffset = vpixel + (hlookup);
         }
       }
     } else {


### PR DESCRIPTION
- closes #352

This bug was introduced in 409dd371b96e863ea626f85faa51db140307d275, probably accidentally.