### PR TITLE
Make the About dialog link to a website that exists.

### DIFF
--- a/bsnes/emulator/emulator.hpp
+++ b/bsnes/emulator/emulator.hpp
@@ -32,7 +32,7 @@ namespace Emulator {
   static const string Version   = "115";
   static const string Copyright = "bsnes team";
   static const string License   = "GPLv3 or later";
-  static const string Website   = "https://bsnes.dev";
+  static const string Website   = "https://github.com/bsnes-emu/bsnes/";
 
   //incremented only when serialization format changes
   static const string SerializerVersion = "115.1";


### PR DESCRIPTION
The registration for bsnes.dev has lapsed a long time ago, the GitHub repo is effectively the website now.

Fixes #354