### PR TITLE
system: Use strict serialization method for ICD

### DIFF
--- a/bsnes/sfc/system/system.cpp
+++ b/bsnes/sfc/system/system.cpp
@@ -26,6 +26,7 @@ auto System::runToSave() -> void {
   //these games will periodically deadlock when using "Fast" synchronization
   if(cartridge.headerTitle() == "Star Ocean") method = "Strict";
   if(cartridge.headerTitle() == "TALES OF PHANTASIA") method = "Strict";
+  if(cartridge.has.ICD) method = "Strict";
 
   //fallback in case of unrecognized method specified
   if(method != "Fast" && method != "Strict") method = "Fast";


### PR DESCRIPTION
Backport of https://gitlab.com/jgemu/bsnes/-/commit/7d8dbd723c5803eba817f455761c6f724406c73c

Otherwise SGB savestates sometimes corrupted, see https://gitlab.com/jgemu/bsnes/-/issues/7