### PR TITLE
Remove Qt 4 support.

### DIFF
--- a/hiro/GNUmakefile
+++ b/hiro/GNUmakefile
@@ -57,12 +57,6 @@ ifneq ($(filter $(platform),linux bsd),)
     hiro.options = -L/usr/local/lib -lX11 $(shell pkg-config --libs gtk+-3.0 gtksourceview-3.0)
   endif
 
-  ifeq ($(hiro),qt4)
-    moc = /usr/local/lib/qt4/bin/moc
-    hiro.flags   = $(flags.cpp) -DHIRO_QT=4 $(shell pkg-config --cflags QtCore QtGui)
-    hiro.options = -L/usr/local/lib -lX11 $(shell pkg-config --libs QtCore QtGui)
-  endif
-
   ifeq ($(hiro),qt5)
     moc = $(shell pkg-config --variable=host_bins Qt5Core)/moc
     hiro.flags   = $(flags.cpp) -DHIRO_QT=5 -fPIC $(shell pkg-config --cflags Qt5Core Qt5Gui Qt5Widgets)

--- a/hiro/qt/application.cpp
+++ b/hiro/qt/application.cpp
@@ -63,11 +63,7 @@ auto pApplication::state() -> State& {
 //obviously, it is used as sparingly as possible
 auto pApplication::synchronize() -> void {
   for(auto n : range(8)) {
-    #if HIRO_QT==4 && defined(DISPLAY_XORG)
-    QApplication::syncX();
-    #elif HIRO_QT==5
     QApplication::sync();
-    #endif
     Application::processEvents();
     usleep(2000);
   }

--- a/hiro/qt/header.hpp
+++ b/hiro/qt/header.hpp
@@ -1,8 +1,6 @@
 #include <QApplication>
 #include <QtGui>
-#if HIRO_QT==5
 #include <QtWidgets>
-#endif
 #undef foreach
 
 #include <nall/xorg/guard.hpp>
@@ -13,11 +11,3 @@
 #undef XK_MISCELLANY
 #undef XK_LATIN1
 #include <nall/xorg/guard.hpp>
-
-//Qt 4.8.0 and earlier improperly define the QLOCATION macro
-//in C++11, it is detected as a malformed user-defined literal
-//below is a workaround to fix compilation errors caused by this
-#if HIRO_QT==4
-  #undef  QLOCATION
-  #define QLOCATION "\0" __FILE__ ":" QTOSTRING(__LINE__)
-#endif

--- a/hiro/qt/settings.cpp
+++ b/hiro/qt/settings.cpp
@@ -2,11 +2,7 @@ namespace hiro {
 
 Settings::Settings() {
   string path = {Path::userSettings(), "hiro/"};
-  #if HIRO_QT==4
-  auto document = BML::unserialize(file::read({path, "qt4.bml"}));
-  #elif HIRO_QT==5
   auto document = BML::unserialize(file::read({path, "qt5.bml"}));
-  #endif
 
   #define get(name, type, value) \
     if(auto node = document[name]) value = node.type()
@@ -39,11 +35,7 @@ Settings::~Settings() {
 
   #undef set
 
-  #if HIRO_QT==4
-  file::write({path, "qt4.bml"}, BML::serialize(document));
-  #elif HIRO_QT==5
   file::write({path, "qt5.bml"}, BML::serialize(document));
-  #endif
 }
 
 }

--- a/hiro/qt/widget/table-view-column.cpp
+++ b/hiro/qt/widget/table-view-column.cpp
@@ -102,11 +102,7 @@ auto pTableViewColumn::_parent() -> maybe<pTableView&> {
 auto pTableViewColumn::_setState() -> void {
   if(auto parent = _parent()) {
     auto lock = parent->acquire();
-    #if HIRO_QT==4
-    parent->qtTableView->header()->setResizeMode(self().offset(), state().resizable ? QHeaderView::Interactive : QHeaderView::Fixed);
-    #elif HIRO_QT==5
     parent->qtTableView->header()->setSectionResizeMode(self().offset(), state().resizable ? QHeaderView::Interactive : QHeaderView::Fixed);
-    #endif
     parent->qtTableView->setColumnHidden(self().offset(), !self().visible());
 
     for(auto& item : parent->state().items) {

--- a/hiro/qt/widget/table-view.cpp
+++ b/hiro/qt/widget/table-view.cpp
@@ -8,11 +8,7 @@ auto pTableView::construct() -> void {
   qtTableView->setContextMenuPolicy(Qt::CustomContextMenu);
   qtTableView->setRootIsDecorated(false);
   qtTableView->setHeaderHidden(true);
-  #if HIRO_QT==4
-  qtTableView->header()->setMovable(false);
-  #elif HIRO_QT==5
   qtTableView->header()->setSectionsMovable(false);
-  #endif
 
   qtTableViewDelegate = new QtTableViewDelegate(*this);
   qtTableView->setItemDelegate(qtTableViewDelegate);
@@ -126,11 +122,7 @@ auto pTableView::setHeadered(bool headered) -> void {
 }
 
 auto pTableView::setSortable(bool sortable) -> void {
-  #if HIRO_QT==4
-  qtTableView->header()->setClickable(sortable);
-  #elif HIRO_QT==5
   qtTableView->header()->setSectionsClickable(sortable);
-  #endif
 }
 
 //called on resize/show events

--- a/hiro/qt/window.cpp
+++ b/hiro/qt/window.cpp
@@ -147,11 +147,7 @@ auto pWindow::setFullScreen(bool fullScreen) -> void {
 auto pWindow::setGeometry(Geometry geometry) -> void {
   auto lock = acquire();
   Application::processEvents();
-  #if HIRO_QT==4
-  QApplication::syncX();
-  #elif HIRO_QT==5
   QApplication::sync();
-  #endif
 
   setResizable(state().resizable);
   qtWindow->move(geometry.x() - frameMargin().x(), geometry.y() - frameMargin().y());


### PR DESCRIPTION
Qt 4.8 LTS was released on December 15th, 2011. It hit its official end-of-life on December 31st, 2015. It has been dead for nearly 10 years. Qt 4 is now so old, that it has been removed from Debian long enough that "qt4" doesn't show up in *any* of the indexed package suites in Debian's online package search service.

With that in mind, I think we can safely say nobody is using this, nobody will miss this, and it is beyond time to get rid of it (and probably add Qt 6 support some day.)

Mirrored in:
- ares: https://github.com/ares-emulator/ares/pull/2187
- higan: https://github.com/higan-emu/higan/pull/216