### PR TITLE
hiro/qt: Update deprecated MidButton enumeration

### DIFF
--- a/hiro/qt/mouse.cpp
+++ b/hiro/qt/mouse.cpp
@@ -11,7 +11,7 @@ auto pMouse::pressed(Mouse::Button button) -> bool {
   Qt::MouseButtons buttons = QApplication::mouseButtons();
   switch(button) {
   case Mouse::Button::Left: return buttons & Qt::LeftButton;
-  case Mouse::Button::Middle: return buttons & Qt::MidButton;
+  case Mouse::Button::Middle: return buttons & Qt::MiddleButton;
   case Mouse::Button::Right: return buttons & Qt::RightButton;
   }
   return false;

--- a/hiro/qt/widget/canvas.cpp
+++ b/hiro/qt/widget/canvas.cpp
@@ -120,7 +120,7 @@ auto QtCanvas::mouseMoveEvent(QMouseEvent* event) -> void {
 auto QtCanvas::mousePressEvent(QMouseEvent* event) -> void {
   switch(event->button()) {
   case Qt::LeftButton: p.self().doMousePress(Mouse::Button::Left); break;
-  case Qt::MidButton: p.self().doMousePress(Mouse::Button::Middle); break;
+  case Qt::MiddleButton: p.self().doMousePress(Mouse::Button::Middle); break;
   case Qt::RightButton: p.self().doMousePress(Mouse::Button::Right); break;
   }
 }
@@ -128,7 +128,7 @@ auto QtCanvas::mousePressEvent(QMouseEvent* event) -> void {
 auto QtCanvas::mouseReleaseEvent(QMouseEvent* event) -> void {
   switch(event->button()) {
   case Qt::LeftButton: p.self().doMouseRelease(Mouse::Button::Left); break;
-  case Qt::MidButton: p.self().doMouseRelease(Mouse::Button::Middle); break;
+  case Qt::MiddleButton: p.self().doMouseRelease(Mouse::Button::Middle); break;
   case Qt::RightButton: p.self().doMouseRelease(Mouse::Button::Right); break;
   }
 }

--- a/hiro/qt/widget/label.cpp
+++ b/hiro/qt/widget/label.cpp
@@ -43,7 +43,7 @@ auto pLabel::setText(const string& text) -> void {
 auto QtLabel::mousePressEvent(QMouseEvent* event) -> void {
   switch(event->button()) {
   case Qt::LeftButton: p.self().doMousePress(Mouse::Button::Left); break;
-  case Qt::MidButton: p.self().doMousePress(Mouse::Button::Middle); break;
+  case Qt::MiddleButton: p.self().doMousePress(Mouse::Button::Middle); break;
   case Qt::RightButton: p.self().doMousePress(Mouse::Button::Right); break;
   }
 }
@@ -51,7 +51,7 @@ auto QtLabel::mousePressEvent(QMouseEvent* event) -> void {
 auto QtLabel::mouseReleaseEvent(QMouseEvent* event) -> void {
   switch(event->button()) {
   case Qt::LeftButton: p.self().doMouseRelease(Mouse::Button::Left); break;
-  case Qt::MidButton: p.self().doMouseRelease(Mouse::Button::Middle); break;
+  case Qt::MiddleButton: p.self().doMouseRelease(Mouse::Button::Middle); break;
   case Qt::RightButton: p.self().doMouseRelease(Mouse::Button::Right); break;
   }
 }

--- a/hiro/qt/widget/viewport.cpp
+++ b/hiro/qt/widget/viewport.cpp
@@ -54,7 +54,7 @@ auto QtViewport::mouseMoveEvent(QMouseEvent* event) -> void {
 auto QtViewport::mousePressEvent(QMouseEvent* event) -> void {
   switch(event->button()) {
   case Qt::LeftButton: p.self().doMousePress(Mouse::Button::Left); break;
-  case Qt::MidButton: p.self().doMousePress(Mouse::Button::Middle); break;
+  case Qt::MiddleButton: p.self().doMousePress(Mouse::Button::Middle); break;
   case Qt::RightButton: p.self().doMousePress(Mouse::Button::Right); break;
   }
 }
@@ -62,7 +62,7 @@ auto QtViewport::mousePressEvent(QMouseEvent* event) -> void {
 auto QtViewport::mouseReleaseEvent(QMouseEvent* event) -> void {
   switch(event->button()) {
   case Qt::LeftButton: p.self().doMouseRelease(Mouse::Button::Left); break;
-  case Qt::MidButton: p.self().doMouseRelease(Mouse::Button::Middle); break;
+  case Qt::MiddleButton: p.self().doMouseRelease(Mouse::Button::Middle); break;
   case Qt::RightButton: p.self().doMouseRelease(Mouse::Button::Right); break;
   }
 }


### PR DESCRIPTION
This enum was deprecated in Qt 4.8 and removed in Qt 6.0.

There's still more clean-up that would be needed for Qt 6 support, including uses of `QApplication::desktop()` and `QApplication::hasPendingEvents()`. The former I think can move to `QScreen` APIs, the latter might require Hiro API changes (instead of having anything check the `pendingEvents()` result, there should be an optional higher level `processEvents()` that takes a timeout in milliseconds instead.)