### PR TITLE
hiro/qt: Remove deprecated usage of QApplication::hasPendingEvents

### DIFF
--- a/hiro/core/application.cpp
+++ b/hiro/core/application.cpp
@@ -38,10 +38,6 @@ auto Application::run() -> void {
   return pApplication::run();
 }
 
-auto Application::pendingEvents() -> bool {
-  return pApplication::pendingEvents();
-}
-
 auto Application::processEvents() -> void {
   return pApplication::processEvents();
 }

--- a/hiro/core/application.hpp
+++ b/hiro/core/application.hpp
@@ -13,7 +13,6 @@ struct Application {
   static auto run() -> void;
   static auto scale() -> float;
   static auto scale(float value) -> float;
-  static auto pendingEvents() -> bool;
   static auto processEvents() -> void;
   static auto quit() -> void;
   static auto screenSaver() -> bool;

--- a/hiro/qt/application.cpp
+++ b/hiro/qt/application.cpp
@@ -22,12 +22,13 @@ auto pApplication::run() -> void {
   }
 }
 
-auto pApplication::pendingEvents() -> bool {
-  return QApplication::hasPendingEvents();
-}
-
 auto pApplication::processEvents() -> void {
-  while(pendingEvents()) QApplication::processEvents();
+  //qt6 has no means to spin the event loop indefinitely anymore
+  //this is likely to prevent bugs where events produced during the loop spin forever
+  //lets match hiro gtk and spin for a max of 50ms
+  //note that this overload of processEvents *will* spin, but it does exit if the queue is empty
+  //so it basically gives us the behavior from before, but with a 50ms cap, which is probably good
+  QApplication::processEvents(QEventLoop::AllEvents, 50);
 }
 
 auto pApplication::quit() -> void {

--- a/hiro/qt/application.hpp
+++ b/hiro/qt/application.hpp
@@ -6,7 +6,6 @@ struct pApplication {
   static auto exit() -> void;
   static auto modal() -> bool;
   static auto run() -> void;
-  static auto pendingEvents() -> bool;
   static auto processEvents() -> void;
   static auto quit() -> void;
   static auto setScreenSaver(bool screenSaver) -> void;


### PR DESCRIPTION
Qt 6 no longer allows us to poll for the status of the event loop. However, Qt 6 does still have a `processEvents` function, and the overload with the timeout actually spins the event loop and returns as early as there are no more events in it. That's basically what we want to do. We could run this with a really huge timeout, but that would just make it more likely that hiro freezes up, so instead let's mirror hiro/gtk3 and use a 50ms timeout.

This also removes the public `Application::pendingEvents` API which does not seem like it was used by bsnes/higan/ares anyways.