### PR TITLE
hiro/qt: Fix deprecated QWheelEvent->{delta,orientation}() usage

### DIFF
--- a/hiro/qt/widget/hex-edit.cpp
+++ b/hiro/qt/widget/hex-edit.cpp
@@ -271,8 +271,9 @@ auto QtHexEdit::keyPressEventAcknowledge(QKeyEvent* event) -> void {
 }
 
 auto QtHexEdit::wheelEvent(QWheelEvent* event) -> void {
-  if(event->orientation() == Qt::Vertical) {
-    signed offset = event->delta() < 0 ? +1 : -1;
+  auto angleDelta = event->angleDelta();
+  if(qAbs(angleDelta.x()) <= qAbs(angleDelta.y())) {
+    signed offset = angleDelta.y() < 0 ? +1 : -1;
     p._scrollTo(p.qtScrollBar->sliderPosition() + offset);
     event->accept();
   }
@@ -281,8 +282,9 @@ auto QtHexEdit::wheelEvent(QWheelEvent* event) -> void {
 auto QtHexEditScrollBar::event(QEvent* event) -> bool {
   if(event->type() == QEvent::Wheel) {
     auto wheelEvent = (QWheelEvent*)event;
-    if(wheelEvent->orientation() == Qt::Vertical) {
-      signed offset = wheelEvent->delta() < 0 ? +1 : -1;
+    auto angleDelta = wheelEvent->angleDelta();
+    if(qAbs(angleDelta.x()) <= qAbs(angleDelta.y())) {
+      signed offset = angleDelta.y() < 0 ? +1 : -1;
       p._scrollTo(sliderPosition() + offset);
       return true;
     }


### PR DESCRIPTION
The `orientation()` and `delta()` methods of `QWheelEvent` were deprecated in Qt 5.0 in favor of `angleDelta()`, which expresses higher-fidelity data for devices like trackpads. In order to keep the behavior 100% identical, the code used to calculate the orientation() and delta() values in Qt 5.15 is inlined instead. That logic can be seen here:

https://github.com/qt/qtbase/blob/v5.15.17-lts-lgpl/src/gui/kernel/qevent.cpp#L876-L884

Following this logic, we also break the tie for orientation in favor of vertical scrolling.

Since there is no actual `HexEdit` usage in bsnes, I tested it by putting a dummy `HexEdit` widget inside the bsnes Presentation window. Scrolling seemed to work as expected.