### PR TITLE
hiro/qt: Use `QScreen` for `Monitor`

### DIFF
--- a/hiro/qt/monitor.cpp
+++ b/hiro/qt/monitor.cpp
@@ -3,24 +3,23 @@
 namespace hiro {
 
 auto pMonitor::count() -> uint {
-  return QApplication::desktop()->screenCount();
+  return QApplication::screens().size();
 }
 
 auto pMonitor::dpi(uint monitor) -> Position {
-  //Qt does not support per-monitor DPI retrieval
   return {
-    QApplication::desktop()->logicalDpiX(),
-    QApplication::desktop()->logicalDpiY()
+    QApplication::screens().at(monitor)->logicalDotsPerInchX(),
+    QApplication::screens().at(monitor)->logicalDotsPerInchY()
   };
 }
 
 auto pMonitor::geometry(uint monitor) -> Geometry {
-  QRect rectangle = QApplication::desktop()->screenGeometry(monitor);
+  QRect rectangle = QApplication::screens().at(monitor)->geometry();
   return {rectangle.x(), rectangle.y(), rectangle.width(), rectangle.height()};
 }
 
 auto pMonitor::primary() -> uint {
-  return QApplication::desktop()->primaryScreen();
+  return QApplication::screens().indexOf(QApplication::primaryScreen());
 }
 
 auto pMonitor::workspace(uint monitor) -> Geometry {

--- a/hiro/qt/window.cpp
+++ b/hiro/qt/window.cpp
@@ -83,9 +83,9 @@ auto pWindow::handle() const -> uintptr_t {
 }
 
 auto pWindow::monitor() const -> uint {
-  int monitor = QDesktopWidget().screenNumber(qtWindow);
-  if(monitor < 0) monitor = Monitor::primary();
-  return monitor;
+  auto screen = qtWindow->window()->windowHandle()->screen();
+  if(screen == nullptr) return Monitor::primary();
+  return QApplication::screens().indexOf(screen);
 }
 
 auto pWindow::remove(sMenuBar menuBar) -> void {


### PR DESCRIPTION
Qt 5 introduces `QScreen`, which can be used to implement most of the functionality needed by `Monitor`, although some of it probably won't make sense when using Wayland.