### PR TITLE
hiro/qt: Add Qt 6 support

### DIFF
--- a/hiro/GNUmakefile
+++ b/hiro/GNUmakefile
@@ -57,6 +57,12 @@ ifneq ($(filter $(platform),linux bsd),)
     hiro.options = -L/usr/local/lib -lX11 $(shell pkg-config --libs gtk+-3.0 gtksourceview-3.0)
   endif
 
+  ifeq ($(hiro),qt6)
+    moc = $(shell pkg-config --variable=libexecdir Qt6Core)/moc
+    hiro.flags   = $(flags.cpp) -DHIRO_QT=6 -fPIC $(shell pkg-config --cflags Qt6Core Qt6Gui Qt6Widgets)
+    hiro.options = -L/usr/local/lib -lX11 $(shell pkg-config --libs Qt6Core Qt6Gui Qt6Widgets)
+  endif
+
   ifeq ($(hiro),qt5)
     moc = $(shell pkg-config --variable=host_bins Qt5Core)/moc
     hiro.flags   = $(flags.cpp) -DHIRO_QT=5 -fPIC $(shell pkg-config --cflags Qt5Core Qt5Gui Qt5Widgets)


### PR DESCRIPTION
Depends on #365, #366, #367, and #368.

I created separate PRs for the other changes mainly to try to make it so that each change could be justified individually, especially when there's any non-trivial changes (i.e. changing the Hiro API, or making a change where it is less obvious that the new version is identical to the old version.)

This does allow for a build of bsnes that uses Qt 6, though it still has the bugs that occur with Qt 5.