### PR TITLE
Remove GTK+2 support.

### DIFF
--- a/hiro/GNUmakefile
+++ b/hiro/GNUmakefile
@@ -8,11 +8,6 @@ ifeq ($(platform),windows)
     hiro.options = -lkernel32 -luser32 -lgdi32 -ladvapi32 -lole32 -lcomctl32 -lcomdlg32 -luxtheme -lmsimg32 -lshlwapi -ldwmapi
   endif
 
-  ifeq ($(hiro),gtk2)
-    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell pkg-config --cflags gtk+-2.0) -Wno-deprecated-declarations
-    hiro.options = $(shell pkg-config --libs gtk+-2.0)
-  endif
-
   ifeq ($(hiro),gtk3)
     hiro.flags   = $(flags.cpp) -DHIRO_GTK=3 $(shell pkg-config --cflags gtk+-3.0) -Wno-deprecated-declarations
     hiro.options = $(shell pkg-config --libs gtk+-3.0)
@@ -33,17 +28,6 @@ endif
 ifneq ($(filter $(platform),linux bsd),)
   ifeq ($(hiro),)
     hiro := gtk3
-  endif
-
-  ifeq ($(hiro),gtk2)
-    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell pkg-config --cflags gtk+-2.0) -Wno-deprecated-declarations
-    hiro.options = -L/usr/local/lib -lX11 $(shell pkg-config --libs gtk+-2.0)
-  endif
-
-  ifeq ($(hiro),gtk2-se)
-    flags       += -DHiro_SourceEdit
-    hiro.flags   = $(flags.cpp) -DHIRO_GTK=2 $(shell pkg-config --cflags gtk+-2.0 gtksourceview-2.0) -Wno-deprecated-declarations
-    hiro.options = -L/usr/local/lib -lX11 $(shell pkg-config --libs gtk+-2.0 gtksourceview-2.0)
   endif
 
   ifeq ($(hiro),gtk3)

--- a/hiro/gtk/application.cpp
+++ b/hiro/gtk/application.cpp
@@ -141,32 +141,6 @@ auto pApplication::initialize() -> void {
   g_object_set(gtkSettings, "gtk-im-module", "gtk-im-context-simple", nullptr);
   #endif
 
-  #if HIRO_GTK==2
-  gtk_rc_parse_string(R"(
-    style "HiroWindow"
-    {
-      GtkWindow::resize-grip-width = 0
-      GtkWindow::resize-grip-height = 0
-    }
-    class "GtkWindow" style "HiroWindow"
-
-    style "HiroTreeView"
-    {
-      GtkTreeView::vertical-separator = 0
-    }
-    class "GtkTreeView" style "HiroTreeView"
-
-    style "HiroTabFrameCloseButton"
-    {
-      GtkWidget::focus-line-width = 0
-      GtkWidget::focus-padding = 0
-      GtkButton::default-border = {0, 0, 0, 0}
-      GtkButton::default-outer-border = {0, 0, 0, 0}
-      GtkButton::inner-border = {0, 1, 0, 0}
-    }
-    widget_class "*.<GtkNotebook>.<GtkHBox>.<GtkButton>" style "HiroTabFrameCloseButton"
-  )");
-  #elif HIRO_GTK==3
   GtkCssProvider *provider;
   GdkScreen *screen;
 
@@ -179,7 +153,6 @@ auto pApplication::initialize() -> void {
 
   screen = gdk_screen_get_default();
   gtk_style_context_add_provider_for_screen(screen, GTK_STYLE_PROVIDER (provider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-  #endif
 
   pKeyboard::initialize();
 }

--- a/hiro/gtk/header.hpp
+++ b/hiro/gtk/header.hpp
@@ -15,13 +15,7 @@
   #include <gdk/gdkkeysyms.h>
   #include <gtk/gtk.h>
   #if defined(Hiro_SourceEdit)
-    #if HIRO_GTK==2
-      #include <gtksourceview/gtksourceview.h>
-      #include <gtksourceview/gtksourcelanguagemanager.h>
-      #include <gtksourceview/gtksourcestyleschememanager.h>
-    #elif HIRO_GTK==3
-      #include <gtksourceview/gtksource.h>
-    #endif
+    #include <gtksourceview/gtksource.h>
   #endif
   #include <nall/windows/guard.hpp>
   #include <nall/windows/registry.hpp>
@@ -37,13 +31,7 @@
   #include <gdk/gdkkeysyms.h>
   #include <gtk/gtk.h>
   #if defined(Hiro_SourceEdit)
-    #if HIRO_GTK==2
-      #include <gtksourceview/gtksourceview.h>
-      #include <gtksourceview/gtksourcelanguagemanager.h>
-      #include <gtksourceview/gtksourcestyleschememanager.h>
-    #elif HIRO_GTK==3
-      #include <gtksourceview/gtksource.h>
-    #endif
+    #include <gtksourceview/gtksource.h>
   #endif
   #include <nall/xorg/guard.hpp>
 #endif

--- a/hiro/gtk/monitor.cpp
+++ b/hiro/gtk/monitor.cpp
@@ -1,65 +1,44 @@
 #if defined(Hiro_Monitor)
 
-//GTK 3.22 adds new monitor functions
-//using GTK 2.x functions as FreeBSD 10.1 uses GTK 3.8
-
 namespace hiro {
 
 auto pMonitor::count() -> uint {
-  #if HIRO_GTK==2 || 1
-  return gdk_screen_get_n_monitors(gdk_screen_get_default());
-  #elif HIRO_GTK==3
   return gdk_display_get_n_monitors(gdk_display_get_default());
-  #endif
 }
 
 auto pMonitor::dpi(uint monitor) -> Position {
-  #if HIRO_GTK==2 || 1
-  //GTK2 does not support either per-monitor or per-axis DPI reporting
-  float dpi = round(gdk_screen_get_resolution(gdk_screen_get_default()));
-  return {dpi, dpi};
-  #elif HIRO_GTK==3
   auto gdkMonitor = gdk_display_get_monitor(gdk_display_get_default(), monitor);
+  auto monitorGeometry = geometry(monitor);
+  auto scaleFactor = gdk_monitor_get_scale_factor(gdkMonitor);
   return {
-    round(gdk_monitor_get_width(gdkMonitor) / (gdk_monitor_get_width_mm(gdkMonitor) / 25.4)),
-    round(gdk_monitor_get_height(gdkMonitor) / (gdk_monitor_get_height_mm(gdkMonitor) / 25.4))
+    round(monitorGeometry.width() * scaleFactor / (gdk_monitor_get_width_mm(gdkMonitor) / 25.4)),
+    round(monitorGeometry.height() * scaleFactor / (gdk_monitor_get_height_mm(gdkMonitor) / 25.4))
   };
-  #endif
 }
 
 auto pMonitor::geometry(uint monitor) -> Geometry {
   GdkRectangle rectangle = {};
-  #if HIRO_GTK==2 || 1
-  gdk_screen_get_monitor_geometry(gdk_screen_get_default(), monitor, &rectangle);
-  #elif HIRO_GTK==3
   auto gdkMonitor = gdk_display_get_monitor(gdk_display_get_default(), monitor);
-  gdk_monitor_get_geometry(monitor, &rectangle);
-  #endif
+  gdk_monitor_get_geometry(gdkMonitor, &rectangle);
   return {rectangle.x, rectangle.y, rectangle.width, rectangle.height};
 }
 
 auto pMonitor::primary() -> uint {
-  #if HIRO_GTK==2 || 1
-  return gdk_screen_get_primary_monitor(gdk_screen_get_default());
-  #elif HIRO_GTK==3
-  return gdk_display_get_primary_monitor(gdk_display_get_default());
-  #endif
+  auto display = gdk_display_get_default();
+  auto primary = gdk_display_get_primary_monitor(display);
+
+  // gdk_display_get_primary_monitor() returns a &GdkMonitor, but most APIs
+  // want an index number.
+  for (auto i = 1; i < gdk_display_get_n_monitors(display); i++ )
+    if (primary == gdk_display_get_monitor(display, i)) return i;
+  return 0;
 }
 
 auto pMonitor::workspace(uint monitor) -> Geometry {
-  #if HIRO_GTK==2 || 1
-  if(Monitor::count() == 1) {
-    return Desktop::workspace();
-  } else {
-    //it is currently unknown how to get per-monitor workspace areas, use geometry instead
-    return Monitor::geometry(monitor);
-  }
-  #elif HIRO_GTK==3
   auto gdkMonitor = gdk_display_get_monitor(gdk_display_get_default(), monitor);
   GdkRectangle rectangle = {};
-  gdk_monitor_get_workarea(monitor, &rectangle);
+  gdk_monitor_get_workarea(gdkMonitor, &rectangle);
   return {rectangle.x, rectangle.y, rectangle.width, rectangle.height};
-  #endif
 }
 
 }

--- a/hiro/gtk/settings.cpp
+++ b/hiro/gtk/settings.cpp
@@ -2,11 +2,7 @@ namespace hiro {
 
 Settings::Settings() {
   string path = {Path::userSettings(), "hiro/"};
-  #if HIRO_GTK==2
-  auto document = BML::unserialize(file::read({path, "gtk2.bml"}));
-  #elif HIRO_GTK==3
   auto document = BML::unserialize(file::read({path, "gtk3.bml"}));
-  #endif
 
   #define get(name, type, value) \
     if(auto node = document[name]) value = node.type()
@@ -45,11 +41,7 @@ Settings::~Settings() {
 
   #undef set
 
-  #if HIRO_GTK==2
-  file::write({path, "gtk2.bml"}, BML::serialize(document));
-  #elif HIRO_GTK==3
   file::write({path, "gtk3.bml"}, BML::serialize(document));
-  #endif
 }
 
 }

--- a/hiro/gtk/widget/canvas.cpp
+++ b/hiro/gtk/widget/canvas.cpp
@@ -46,11 +46,7 @@ auto pCanvas::construct() -> void {
   g_signal_connect(G_OBJECT(gtkWidget), "button-press-event", G_CALLBACK(Canvas_mousePress), (gpointer)this);
   g_signal_connect(G_OBJECT(gtkWidget), "button-release-event", G_CALLBACK(Widget_mouseRelease), (gpointer)this);
   g_signal_connect(G_OBJECT(gtkWidget), "drag-data-received", G_CALLBACK(Widget_drop), (gpointer)this);
-  #if HIRO_GTK==2
-  g_signal_connect(G_OBJECT(gtkWidget), "expose-event", G_CALLBACK(Canvas_expose), (gpointer)this);
-  #elif HIRO_GTK==3
   g_signal_connect(G_OBJECT(gtkWidget), "draw", G_CALLBACK(Canvas_draw), (gpointer)this);
-  #endif
   g_signal_connect(G_OBJECT(gtkWidget), "key-press-event", G_CALLBACK(Canvas_keyPress), (gpointer)this);
   g_signal_connect(G_OBJECT(gtkWidget), "enter-notify-event", G_CALLBACK(Widget_mouseEnter), (gpointer)this);
   g_signal_connect(G_OBJECT(gtkWidget), "leave-notify-event", G_CALLBACK(Widget_mouseLeave), (gpointer)this);

--- a/hiro/gtk/widget/hex-edit.cpp
+++ b/hiro/gtk/widget/hex-edit.cpp
@@ -26,11 +26,7 @@ static auto HexEdit_scroll(GtkRange* range, GtkScrollType scroll, double value, 
 }
 
 auto pHexEdit::construct() -> void {
-  #if HIRO_GTK==2
-  gtkWidget = gtk_hbox_new(false, 0);
-  #elif HIRO_GTK==3
   gtkWidget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  #endif
 
   container = gtk_scrolled_window_new(0, 0);
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(container), GTK_POLICY_AUTOMATIC, GTK_POLICY_NEVER);
@@ -41,11 +37,7 @@ auto pHexEdit::construct() -> void {
   gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(subWidget), GTK_WRAP_NONE);
   gtk_container_add(GTK_CONTAINER(container), subWidget);
 
-  #if HIRO_GTK==2
-  scrollBar = gtk_vscrollbar_new(nullptr);
-  #elif HIRO_GTK==3
   scrollBar = gtk_scrollbar_new(GTK_ORIENTATION_VERTICAL, nullptr);
-  #endif
   gtk_range_set_range(GTK_RANGE(scrollBar), 0, 255);
   gtk_range_set_increments(GTK_RANGE(scrollBar), 1, 16);
   gtk_widget_set_sensitive(scrollBar, false);

--- a/hiro/gtk/widget/horizontal-scroll-bar.cpp
+++ b/hiro/gtk/widget/horizontal-scroll-bar.cpp
@@ -10,11 +10,7 @@ static auto HorizontalScrollBar_change(GtkRange* gtkRange, pHorizontalScrollBar*
 }
 
 auto pHorizontalScrollBar::construct() -> void {
-  #if HIRO_GTK==2
-  gtkWidget = gtk_hscrollbar_new(nullptr);
-  #elif HIRO_GTK==3
   gtkWidget = gtk_scrollbar_new(GTK_ORIENTATION_HORIZONTAL, nullptr);
-  #endif
 
   setLength(state().length);
   setPosition(state().position);

--- a/hiro/gtk/widget/horizontal-slider.cpp
+++ b/hiro/gtk/widget/horizontal-slider.cpp
@@ -10,11 +10,7 @@ static auto HorizontalSlider_change(GtkRange* gtkRange, pHorizontalSlider* p) ->
 }
 
 auto pHorizontalSlider::construct() -> void {
-  #if HIRO_GTK==2
-  gtkWidget = gtk_hscale_new_with_range(0, 100, 1);
-  #elif HIRO_GTK==3
   gtkWidget = gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL, 0, 100, 1);
-  #endif
   gtk_scale_set_draw_value(GTK_SCALE(gtkWidget), false);
 
   setLength(state().length);

--- a/hiro/gtk/widget/label.cpp
+++ b/hiro/gtk/widget/label.cpp
@@ -25,7 +25,6 @@ static auto Label_draw(GtkWidget* widget, cairo_t* context, pLabel* p) -> int {
     cairo_set_operator(context, CAIRO_OPERATOR_SOURCE);
     cairo_paint(context);
   } else {
-    #if HIRO_GTK==3
     auto style = gtk_widget_get_style_context(widget);
     if(auto tabFrame = p->self().parentTabFrame(true)) {
       if(auto self = tabFrame->self()) style = gtk_widget_get_style_context(self->gtkWidget);
@@ -33,7 +32,6 @@ static auto Label_draw(GtkWidget* widget, cairo_t* context, pLabel* p) -> int {
     GtkAllocation allocation;
     gtk_widget_get_allocation(widget, &allocation);
     gtk_render_background(style, context, 0, 0, allocation.width, allocation.height);
-    #endif
   }
 
   return false;
@@ -87,11 +85,7 @@ auto pLabel::construct() -> void {
 
   g_signal_connect(G_OBJECT(gtkWidget), "button-press-event", G_CALLBACK(Label_mousePress), (gpointer)this);
   g_signal_connect(G_OBJECT(gtkWidget), "button-release-event", G_CALLBACK(Label_mouseRelease), (gpointer)this);
-  #if HIRO_GTK==2
-  g_signal_connect(G_OBJECT(subWidget), "expose-event", G_CALLBACK(Label_expose), (gpointer)this);
-  #elif HIRO_GTK==3
   g_signal_connect(G_OBJECT(subWidget), "draw", G_CALLBACK(Label_draw), (gpointer)this);
-  #endif
   g_signal_connect(G_OBJECT(gtkWidget), "enter-notify-event", G_CALLBACK(Label_mouseEnter), (gpointer)this);
   g_signal_connect(G_OBJECT(gtkWidget), "leave-notify-event", G_CALLBACK(Label_mouseLeave), (gpointer)this);
 

--- a/hiro/gtk/widget/tab-frame.cpp
+++ b/hiro/gtk/widget/tab-frame.cpp
@@ -186,11 +186,7 @@ auto pTabFrame::_append() -> void {
   lock();
   Tab tab;
   tab.child = gtk_fixed_new();
-  #if HIRO_GTK==2
-  tab.container = gtk_hbox_new(false, 0);
-  #elif HIRO_GTK==3
   tab.container = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  #endif
   tab.image = gtk_image_new();
   tab.title = gtk_label_new("");
   gtk_misc_set_alignment(GTK_MISC(tab.title), 0.0, 0.5);

--- a/hiro/gtk/widget/table-view-column.cpp
+++ b/hiro/gtk/widget/table-view-column.cpp
@@ -7,11 +7,7 @@ auto pTableViewColumn::construct() -> void {
     auto handle = parent.data();
     uint offset = self().offset();
 
-    #if HIRO_GTK==2
-    gtkHeader = gtk_hbox_new(false, 0);
-    #elif HIRO_GTK==3
     gtkHeader = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    #endif
 
     gtkHeaderIcon = gtk_image_new();
     gtk_box_pack_start(GTK_BOX(gtkHeader), gtkHeaderIcon, false, false, 0);

--- a/hiro/gtk/widget/vertical-scroll-bar.cpp
+++ b/hiro/gtk/widget/vertical-scroll-bar.cpp
@@ -10,11 +10,7 @@ static auto VerticalScrollBar_change(GtkRange* gtkRange, pVerticalScrollBar* p) 
 }
 
 auto pVerticalScrollBar::construct() -> void {
-  #if HIRO_GTK==2
-  gtkWidget = gtk_vscrollbar_new(nullptr);
-  #elif HIRO_GTK==3
   gtkWidget = gtk_scrollbar_new(GTK_ORIENTATION_VERTICAL, nullptr);
-  #endif
 
   setLength(state().length);
   setPosition(state().position);

--- a/hiro/gtk/widget/vertical-slider.cpp
+++ b/hiro/gtk/widget/vertical-slider.cpp
@@ -10,11 +10,7 @@ static auto VerticalSlider_change(GtkRange* gtkRange, pVerticalSlider* p) -> voi
 }
 
 auto pVerticalSlider::construct() -> void {
-  #if HIRO_GTK==2
-  gtkWidget = gtk_vscale_new_with_range(0, 100, 1);
-  #elif HIRO_GTK==3
   gtkWidget = gtk_scale_new_with_range(GTK_ORIENTATION_VERTICAL, 0, 100, 1);
-  #endif
   gtk_scale_set_draw_value(GTK_SCALE(gtkWidget), false);
 
   setLength(state().length);

--- a/hiro/gtk/widget/viewport.cpp
+++ b/hiro/gtk/widget/viewport.cpp
@@ -39,11 +39,7 @@ auto pViewport::construct() -> void {
   g_signal_connect(G_OBJECT(gtkWidget), "button-press-event", G_CALLBACK(Viewport_mousePress), (gpointer)this);
   g_signal_connect(G_OBJECT(gtkWidget), "button-release-event", G_CALLBACK(Widget_mouseRelease), (gpointer)this);
   g_signal_connect(G_OBJECT(gtkWidget), "drag-data-received", G_CALLBACK(Widget_drop), (gpointer)this);
-  #if HIRO_GTK==2
-  g_signal_connect(G_OBJECT(gtkWidget), "expose-event", G_CALLBACK(Viewport_expose), (gpointer)this);
-  #elif HIRO_GTK==3
   g_signal_connect(G_OBJECT(gtkWidget), "draw", G_CALLBACK(Viewport_draw), (gpointer)this);
-  #endif
   g_signal_connect(G_OBJECT(gtkWidget), "key-press-event", G_CALLBACK(Viewport_keyPress), (gpointer)this);
   g_signal_connect(G_OBJECT(gtkWidget), "enter-notify-event", G_CALLBACK(Widget_mouseEnter), (gpointer)this);
   g_signal_connect(G_OBJECT(gtkWidget), "leave-notify-event", G_CALLBACK(Widget_mouseLeave), (gpointer)this);

--- a/hiro/gtk/window.cpp
+++ b/hiro/gtk/window.cpp
@@ -31,12 +31,10 @@ static auto Window_draw(GtkWidget* widget, cairo_t* context, pWindow* p) -> sign
     cairo_set_operator(context, CAIRO_OPERATOR_SOURCE);
     cairo_paint(context);
   } else {
-    #if HIRO_GTK==3
     auto style = gtk_widget_get_style_context(widget);
     GtkAllocation allocation;
     gtk_widget_get_allocation(widget, &allocation);
     gtk_render_background(style, context, 0, 0, allocation.width, allocation.height);
-    #endif
   }
 
   return false;
@@ -148,11 +146,7 @@ auto pWindow::construct() -> void {
   gtk_widget_set_app_paintable(widget, true);
   gtk_widget_add_events(widget, GDK_CONFIGURE);
 
-  #if HIRO_GTK==2
-  menuContainer = gtk_vbox_new(false, 0);
-  #elif HIRO_GTK==3
   menuContainer = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  #endif
   gtk_container_add(GTK_CONTAINER(widget), menuContainer);
   gtk_widget_show(menuContainer);
 
@@ -165,11 +159,7 @@ auto pWindow::construct() -> void {
 
   statusContainer = gtk_event_box_new();
   gtkStatus = gtk_statusbar_new();
-  #if HIRO_GTK==2
-  gtk_statusbar_set_has_resize_grip(GTK_STATUSBAR(gtkStatus), true);
-  #elif HIRO_GTK==3
   gtk_window_set_has_resize_grip(GTK_WINDOW(widget), true);
-  #endif
   gtk_container_add(GTK_CONTAINER(statusContainer), gtkStatus);
   gtk_box_pack_start(GTK_BOX(menuContainer), statusContainer, false, false, 0);
   gtk_widget_show(statusContainer);
@@ -183,24 +173,16 @@ auto pWindow::construct() -> void {
   setTitle(state().title);
 
   g_signal_connect(G_OBJECT(widget), "delete-event", G_CALLBACK(Window_close), (gpointer)this);
-  #if HIRO_GTK==2
-  g_signal_connect(G_OBJECT(widget), "expose-event", G_CALLBACK(Window_expose), (gpointer)this);
-  #elif HIRO_GTK==3
   g_signal_connect(G_OBJECT(widget), "draw", G_CALLBACK(Window_draw), (gpointer)this);
-  #endif
   g_signal_connect(G_OBJECT(widget), "configure-event", G_CALLBACK(Window_configure), (gpointer)this);
   g_signal_connect(G_OBJECT(widget), "drag-data-received", G_CALLBACK(Window_drop), (gpointer)this);
   g_signal_connect(G_OBJECT(widget), "key-press-event", G_CALLBACK(Window_keyPress), (gpointer)this);
   g_signal_connect(G_OBJECT(widget), "key-release-event", G_CALLBACK(Window_keyRelease), (gpointer)this);
   g_signal_connect(G_OBJECT(widget), "realize", G_CALLBACK(Window_realize), (gpointer)this);
   g_signal_connect(G_OBJECT(formContainer), "size-allocate", G_CALLBACK(Window_sizeAllocate), (gpointer)this);
-  #if HIRO_GTK==2
-  g_signal_connect(G_OBJECT(formContainer), "size-request", G_CALLBACK(Window_sizeRequest), (gpointer)this);
-  #elif HIRO_GTK==3
   auto widgetClass = GTK_WIDGET_GET_CLASS(formContainer);
   widgetClass->get_preferred_width  = Window_getPreferredWidth;
   widgetClass->get_preferred_height = Window_getPreferredHeight;
-  #endif
   g_signal_connect(G_OBJECT(widget), "unrealize", G_CALLBACK(Window_unrealize), (gpointer)this);
   g_signal_connect(G_OBJECT(widget), "window-state-event", G_CALLBACK(Window_stateEvent), (gpointer)this);
 
@@ -404,13 +386,9 @@ auto pWindow::setModal(bool modal) -> void {
 
 auto pWindow::setResizable(bool resizable) -> void {
   gtk_window_set_resizable(GTK_WINDOW(widget), resizable);
-  #if HIRO_GTK==2
-  gtk_statusbar_set_has_resize_grip(GTK_STATUSBAR(gtkStatus), resizable);
-  #elif HIRO_GTK==3
   bool statusBarVisible = false;
   if(auto statusBar = state().statusBar) statusBarVisible = statusBar->visible();
   gtk_window_set_has_resize_grip(GTK_WINDOW(widget), resizable && statusBarVisible);
-  #endif
 
   setMaximumSize(state().maximumSize);
   setMinimumSize(state().minimumSize);
@@ -591,11 +569,7 @@ auto pWindow::_synchronizeMargin() -> void {
   GdkRectangle border, client;
   gdk_window_get_frame_extents(window, &border);
   gdk_window_get_origin(window, &client.x, &client.y);
-  #if HIRO_GTK==2
-  gdk_window_get_geometry(window, nullptr, nullptr, &client.width, &client.height, nullptr);
-  #elif HIRO_GTK==3
   gdk_window_get_geometry(window, nullptr, nullptr, &client.width, &client.height);
-  #endif
 
   settings.geometry.frameX = client.x - border.x;
   settings.geometry.frameY = client.y - border.y;


### PR DESCRIPTION
Although it had HIRO_GTK==3 sections, hiro/gtk/monitor.cpp was actually using deprecated GTK+2 APIs on GTK3, and the GTK3 code was broken and wouldn't compile.

I only have a single, standard-resolution monitor here to test with, I would appreciate testing from people who have multiple monitors, and hi-DPI monitors too since I modified that code.