### PR TITLE
CX4 program cache behaviour improvements

### DIFF
--- a/bsnes/processor/hg51b/hg51b.cpp
+++ b/bsnes/processor/hg51b/hg51b.cpp
@@ -89,6 +89,7 @@ auto HG51B::cache() -> bool {
   for(uint offset : range(256)) {
     step(wait(address));
     programRAM[io.cache.page][offset]  = read(address++) << 0;
+    step(wait(address));
     programRAM[io.cache.page][offset] |= read(address++) << 8;
   }
   return io.cache.enable = 0, true;

--- a/bsnes/processor/hg51b/hg51b.cpp
+++ b/bsnes/processor/hg51b/hg51b.cpp
@@ -72,15 +72,18 @@ auto HG51B::suspend() -> void {
 auto HG51B::cache() -> bool {
   uint24 address = io.cache.base + r.pb * 512;
 
-  //try to use the current page ...
-  if(io.cache.address[io.cache.page] == address) return io.cache.enable = 0, true;
-  //if it's not valid, try to use the other page ...
-  io.cache.page ^= 1;
-  if(io.cache.address[io.cache.page] == address) return io.cache.enable = 0, true;
-  //if it's not valid, try to load into the other page ...
-  if(io.cache.lock[io.cache.page]) io.cache.page ^= 1;
-  //if it's locked, try to load into the first page ...
-  if(io.cache.lock[io.cache.page]) return io.cache.enable = 0, false;
+  if(io.cache.preload == 0) {
+    //try to use the current page ...
+    if(io.cache.address[io.cache.page] == address) return io.cache.enable = 0, true;
+    //if it's not valid, try to use the other page ...
+    io.cache.page ^= 1;
+    if(io.cache.address[io.cache.page] == address) return io.cache.enable = 0, true;
+    //if it's not valid, try to load into the other page ...
+    if(io.cache.lock[io.cache.page]) io.cache.page ^= 1;
+    //if it's locked, try to load into the first page ...
+    if(io.cache.lock[io.cache.page]) return io.cache.enable = 0, false;
+  }
+  io.cache.preload = 0;
 
   io.cache.address[io.cache.page] = address;
   for(uint offset : range(256)) {

--- a/bsnes/processor/hg51b/hg51b.hpp
+++ b/bsnes/processor/hg51b/hg51b.hpp
@@ -152,6 +152,7 @@ protected:
     struct Cache {
       uint1  enable;
       uint1  page;
+      uint1  preload;
       uint1  lock[2];
       uint24 address[2];  //cache address is in bytes; so 24-bit
       uint24 base;        //base address is also in bytes

--- a/bsnes/processor/hg51b/registers.cpp
+++ b/bsnes/processor/hg51b/registers.cpp
@@ -12,13 +12,13 @@ auto HG51B::readRegister(uint7 address) -> uint24 {
   case 0x2e:
     io.bus.enable  = 1;
     io.bus.reading = 1;
-    io.bus.pending = 1 + io.wait.rom;
+    io.bus.pending = io.wait.rom;
     io.bus.address = r.mar;
     return 0x000000;
   case 0x2f:
     io.bus.enable  = 1;
     io.bus.reading = 1;
-    io.bus.pending = 1 + io.wait.ram;
+    io.bus.pending = io.wait.ram;
     io.bus.address = r.mar;
     return 0x000000;
 
@@ -76,13 +76,13 @@ auto HG51B::writeRegister(uint7 address, uint24 data) -> void {
   case 0x2e:
     io.bus.enable  = 1;
     io.bus.writing = 1;
-    io.bus.pending = 1 + io.wait.rom;
+    io.bus.pending = io.wait.rom;
     io.bus.address = r.mar;
     return;
   case 0x2f:
     io.bus.enable  = 1;
     io.bus.writing = 1;
-    io.bus.pending = 1 + io.wait.ram;
+    io.bus.pending = io.wait.ram;
     io.bus.address = r.mar;
     return;
 

--- a/bsnes/sfc/coprocessor/hitachidsp/memory.cpp
+++ b/bsnes/sfc/coprocessor/hitachidsp/memory.cpp
@@ -196,7 +196,11 @@ auto HitachiDSP::writeIO(uint address, uint8 data) -> void {
 
   case 0x7f48:
     io.cache.page = data & 1;
-    if(io.halt) io.cache.enable = 1;
+    if(io.halt) {
+      r.pb = io.cache.pb;
+      io.cache.preload = 1;
+      io.cache.enable = 1;
+    }
     return;
 
   case 0x7f49: io.cache.base = io.cache.base & 0xffff00 | data <<  0; return;


### PR DESCRIPTION
- When triggering a cache preload by writing to $7f48, update the pb register with the prepared program page
- When preloading a page, ignore all runtime checks and reload the page immediately

I have been looking into CX4 emulation lately, as it historically hasn't gotten a ton of attention compared to other chips and has been known to run quite fast compared to original hardware. By observing how Mega Man X2/X3 sets up the program cache on the CX4, I believe these two changes are consistent with assumptions made by the games on the CX4's caching behaviour.

I have created a [comparison video](https://www.youtube.com/watch?v=Laj1P41fXzU) of the Mega Man X2 opening sequence, showing the difference between current `master`, my commit `6c5f03e`, and footage recorded from my SNES and original cart. These changes result in a significant accuracy improvement on the wireframe head section of the opening.

I am certainly open to feedback on these changes as I am not a hardware expert. Just looking to do what I can to improve emulation accuracy for X2/X3. Thanks!