### PR TITLE
GSU: 3 emulation accuracy fixes (STOP flush, R14 stall, restart state)

### DIFF
--- a/bsnes/sfc/coprocessor/superfx/core.cpp
+++ b/bsnes/sfc/coprocessor/superfx/core.cpp
@@ -1,4 +1,8 @@
 auto SuperFX::stop() -> void {
+  //flush pixel caches to RAM before halting, matching real hardware
+  //behavior where STOP commits all pending pixel data
+  flushPixelCache(pixelcache[1]);
+  flushPixelCache(pixelcache[0]);
   cpu.irq(1);
 }
 

--- a/bsnes/sfc/coprocessor/superfx/io.cpp
+++ b/bsnes/sfc/coprocessor/superfx/io.cpp
@@ -67,7 +67,13 @@ auto SuperFX::writeIO(uint addr, uint8 data) -> void {
     }
     if(n == 14) updateROMBuffer();
 
-    if(addr == 0x301f) regs.sfr.g = 1;
+    if(addr == 0x301f) {
+      //clear stale state from previous execution before restarting
+      regs.romcl = 0;
+      regs.ramcl = 0;
+      regs.sfr.r = 0;
+      regs.sfr.g = 1;
+    }
     return;
   }
 

--- a/bsnes/sfc/coprocessor/superfx/superfx.cpp
+++ b/bsnes/sfc/coprocessor/superfx/superfx.cpp
@@ -29,7 +29,9 @@ auto SuperFX::main() -> void {
 
   if(regs.r[14].modified) {
     regs.r[14].modified = false;
-    updateROMBuffer();
+    //skip ROM prefetch when executing from RAM (PBR >= $60)
+    //the prefetch is a no-op in that context and the stall wastes cycles
+    if(regs.pbr < 0x60) updateROMBuffer();
   }
 
   if(regs.r[15].modified) {


### PR DESCRIPTION
## Summary

Three GSU (SuperFX) emulation fixes that improve accuracy for programs executing from Game Pak RAM and using the PLOT pixel pipeline:

1. **STOP pixel cache flush** (`core.cpp`) — flush both pixel caches before halting, matching real hardware behavior where STOP commits pending pixels to RAM
2. **R14 ROM stall guard** (`superfx.cpp`) — skip ROM bus stall for R14 prefetch when executing from RAM (PBR >= $60), since the prefetch is a no-op in that context
3. **Restart state reset on GO** (`io.cpp`) — clear stale romcl/ramcl delays and ROM-reading flag when the SNES CPU restarts the GSU via R15H write, preventing previous execution's pending bus operations from blocking the new program

## Context

These fixes were discovered while developing a homebrew HiROM+GSU cartridge that loads custom programs into GSU work RAM. The bugs are masked by commercial LoROM+GSU games (which use fixed ROM-based programs with predictable cache/bus patterns) but break homebrew programs that restart the GSU with new code.

The same fixes were submitted and verified for Mesen2 ([PR #90](https://github.com/SourMesen/Mesen2/pull/90)), which inherited the same code patterns.

## Verified — no regressions

- **Star Fox** — no regressions
- **Star Fox 2** — no regressions
- **Yoshi's Island** — no regressions (heaviest GSU user)
- **Winter Gold** — no regressions (3D polygon rendering)

Test ROM: https://github.com/astrobleem/SNES-HiRomGsuTest

🤖 Generated with [Claude Code](https://claude.com/claude-code)