### PR TITLE
Fix horizontal offset in high-resolution offset-by-tile mode

### DIFF
--- a/bsnes/sfc/ppu-fast/background.cpp
+++ b/bsnes/sfc/ppu-fast/background.cpp
@@ -49,8 +49,8 @@ auto PPU::Line::renderBackground(PPU::IO::Background& self, uint8 source) -> voi
     if(offsetPerTileMode) {
       uint validBit = 0x2000 << source;
       uint offsetX = x + (hscroll & 7);
-      if(offsetX >= 8) {  //first column is exempt
-        uint hlookup = getTile(io.bg3, (offsetX - 8) + (io.bg3.hoffset & ~7), io.bg3.voffset + 0);
+      if(offsetX >= (1 << tileWidth)) {  //first column is exempt
+        uint hlookup = getTile(io.bg3, offsetX - (1 << tileWidth) + ((io.bg3.hoffset & ~7) << hires), io.bg3.voffset + 0);
         if(io.bgMode == 4) {
           if(hlookup & validBit) {
             if(!(hlookup & 0x8000)) {
@@ -60,7 +60,7 @@ auto PPU::Line::renderBackground(PPU::IO::Background& self, uint8 source) -> voi
             }
           }
         } else {
-          uint vlookup = getTile(io.bg3, (offsetX - 8) + (io.bg3.hoffset & ~7), io.bg3.voffset + 8);
+          uint vlookup = getTile(io.bg3, offsetX - (1 << tileWidth) + ((io.bg3.hoffset & ~7) << hires), io.bg3.voffset + 8);
           if(hlookup & validBit) {
             hoffset = offsetX + (hlookup & ~7);
           }

--- a/bsnes/sfc/ppu/background.cpp
+++ b/bsnes/sfc/ppu/background.cpp
@@ -125,14 +125,14 @@ auto PPU::Background::fetchNameTable() -> void {
 auto PPU::Background::fetchOffset(uint y) -> void {
   if(ppu.vcounter() == 0) return;
 
-  uint characterIndex = ppu.hcounter() >> 5 << hires();
+  uint characterIndex = ppu.hcounter() >> 5;
   uint x = characterIndex << 3;
 
   uint hoffset = x + (io.hoffset & ~7);
   uint voffset = y + (io.voffset);
 
   uint vtiles = 3 + io.tileSize;
-  uint htiles = !hires() ? vtiles : 4;
+  uint htiles = !hires() ? vtiles : 3;
 
   uint htile = hoffset >> htiles;
   uint vtile = voffset >> vtiles;


### PR DESCRIPTION
- closes #384

The intuition behind this fix is that if we're in hires mode (bg mode 5 or 6), the background's `hoffset` needs to be doubled. In ppu-fast, I've just added an additional left-shift to double this value and in the accurate ppu we just do one less shift right (alternatively, we could left-shift both `io.hoffset` and `characterIndex` individually).

In ppu-fast, I've applied an additional fix to the "column - 1" logic by replacing `8` with `1 << tileWidth`, which is the same for 8x8 tiles and doubled (16) for 16x[8/16] tiles. This seems to be visually accurate based on the `opt-big-map6.sfc` testrom provided in the original issue.

I believe this is a problem exclusive to bg mode 6 because that's the only hires+offset-by-tile mode.