### PR TITLE
Make our own "is_integral" and "is_signed" traits.

### DIFF
--- a/nall/serializer.hpp
+++ b/nall/serializer.hpp
@@ -139,7 +139,7 @@ struct serializer {
   #endif
 
   template<typename T> auto operator()(T& value, typename std::enable_if<has_serialize<T>::value>::type* = 0) -> serializer& { value.serialize(*this); return *this; }
-  template<typename T> auto operator()(T& value, typename std::enable_if<std::is_integral<T>::value>::type* = 0) -> serializer& { return integer(value); }
+  template<typename T> auto operator()(T& value, typename std::enable_if<is_integral<T>::value>::type* = 0) -> serializer& { return integer(value); }
   template<typename T> auto operator()(T& value, typename std::enable_if<std::is_floating_point<T>::value>::type* = 0) -> serializer& { return real(value); }
   template<typename T> auto operator()(T& value, typename std::enable_if<std::is_array<T>::value>::type* = 0) -> serializer& { return array(value); }
   template<typename T> auto operator()(T& value, uint size, typename std::enable_if<std::is_pointer<T>::value>::type* = 0) -> serializer& { return array(value, size); }

--- a/nall/traits.hpp
+++ b/nall/traits.hpp
@@ -23,25 +23,29 @@ namespace nall {
   using std::is_base_of;
   using std::is_base_of_v;
   using std::is_function;
-  using std::is_integral;
-  using std::is_integral_v;
   using std::is_same;
   using std::is_same_v;
-  using std::is_signed;
-  using std::is_signed_v;
-  using std::is_unsigned;
-  using std::is_unsigned_v;
   using std::move;
   using std::nullptr_t;
   using std::remove_extent;
   using std::remove_reference;
   using std::swap;
   using std::true_type;
-}
 
-namespace std {
+  //directly specializing std traits would result in undefined behavior
+  template<typename T> struct is_integral : std::is_integral<T> {};
+  template<typename T> struct is_signed   : std::is_signed  <T> {};
+  template<typename T> struct is_unsigned : std::is_unsigned<T> {};
+
+  template<typename T> inline constexpr bool is_integral_v = is_integral<T>::value;
+  template<typename T> inline constexpr bool is_signed_v   = is_signed  <T>::value;
+  template<typename T> inline constexpr bool is_unsigned_v = is_unsigned<T>::value;
+
+  //defined in arithmetic.hpp when unavailable as a builtin
   #if INTMAX_BITS >= 128
-  template<> struct is_signed<int128_t> : true_type {};
+  template<> struct is_integral<int128_t>  : true_type {};
+  template<> struct is_signed<int128_t>    : true_type {};
+  template<> struct is_integral<uint128_t> : true_type {};
   template<> struct is_unsigned<uint128_t> : true_type {};
   #endif
 }


### PR DESCRIPTION
It seems that a lot of compilers implement a 128-bit integer type, but don't hook it up to all the standard library definitions. Previously, nall tried to amend the standard library definitions to match, but although that worked, it wasn't supposed to, and clang++ 20 apparently complains.

Although nothing in bsnes actually uses 128-bit integers for anything, it seems a shame to lose the functionality entirely, so we make our own traits, and adapt the serialization code to use it.

This patch was adapted from ares' commit 6a253b1.